### PR TITLE
Extract parsing int, string and byte into util functions

### DIFF
--- a/gen/main.go
+++ b/gen/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"go/format"
 	"os"
 	"slices"
 	"strings"
@@ -81,7 +82,11 @@ func main() {
 }
 
 func write(dst, s string) {
-	err := os.WriteFile("parser/"+dst, []byte(s), 0666)
+	formattedSource, err := format.Source([]byte(s))
+	if err != nil {
+		panic(err)
+	}
+	err = os.WriteFile("parser/"+dst, formattedSource, 0666)
 	if err != nil {
 		panic(err)
 	}

--- a/gen/main.go
+++ b/gen/main.go
@@ -192,52 +192,49 @@ func generate(typ *def.Class, opt options) string {
 	res += "	_ = v32_\n"
 	res += "	_ = s_\n"
 
-	depth := 2
 	if opt.cpool {
-		res += emitReadI32(1)
-		res += pad(1) + "n := int(v32_)\n"
+		res += emitReadI32()
+		res += "n := int(v32_)\n"
 		if opt.doNotKeepData {
 
 		} else {
 			if opt.sortedIDs {
-				res += pad(1) + fmt.Sprintf("this.IDMap = NewIDMap[%s](n)\n", refName(typ))
+				res += fmt.Sprintf("this.IDMap = NewIDMap[%s](n)\n", refName(typ))
 			} else {
-				res += pad(1) + fmt.Sprintf("this.IDMap = make(map[%s]uint32, n)\n", refName(typ))
+				res += fmt.Sprintf("this.IDMap = make(map[%s]uint32, n)\n", refName(typ))
 			}
-			res += pad(1) + fmt.Sprintf("this.%s = make([]%s, n)\n", name(typ), name(typ))
+			res += fmt.Sprintf("this.%s = make([]%s, n)\n", name(typ), name(typ))
 		}
 		res += "	for i := 0; i < n; i++ {\n"
-	} else {
-		depth = 1
 	}
 
 	if opt.cpool {
-		res += emitReadI32(depth)
+		res += emitReadI32()
 		if opt.doNotKeepData {
 
 		} else {
-			res += pad(depth) + fmt.Sprintf("id := %s(v32_)\n", refName(typ))
+			res += fmt.Sprintf("id := %s(v32_)\n", refName(typ))
 		}
 	}
 
-	res += generateBindLoop(typ, "bind", depth, true)
+	res += generateBindLoop(typ, "bind", true)
 
 	if opt.cpool {
 		if opt.doNotKeepData {
 
 		} else {
 
-			res += pad(depth) + fmt.Sprintf("this.%s[i] = bind.Temp\n", name(typ))
+			res += fmt.Sprintf("this.%s[i] = bind.Temp\n", name(typ))
 
 			if opt.sortedIDs {
-				res += pad(depth) + "this.IDMap.Set(id, i)\n"
+				res += "this.IDMap.Set(id, i)\n"
 			} else {
-				res += pad(depth) + "this.IDMap[id] = uint32(i)\n"
+				res += "this.IDMap[id] = uint32(i)\n"
 			}
 		}
-		res += pad(1) + "}\n"
+		res += "}\n"
 	} else {
-		res += pad(depth) + fmt.Sprintf("*this = bind.Temp\n")
+		res += fmt.Sprintf("*this = bind.Temp\n")
 	}
 	res += "	return pos, nil\n"
 	res += fmt.Sprintf("}\n")
@@ -255,138 +252,138 @@ func generate(typ *def.Class, opt options) string {
 	return res
 }
 
-func generateBindLoop(typ *def.Class, bindName string, depth int, nestedAllowed bool) string {
+func generateBindLoop(typ *def.Class, bindName string, nestedAllowed bool) string {
 	fs := getUniqueFields(typ)
 	cpoolFields := getUniqueCpoolFields(typ)
 	complexFields := getNonBasicFields(typ)
 	_ = complexFields
 	res := ""
 
-	res += pad(depth) + fmt.Sprintf("for %sFieldIndex := 0; %sFieldIndex < len(%s.Fields); %sFieldIndex++ {\n", bindName, bindName, bindName, bindName)
-	res += pad(depth) + fmt.Sprintf("	%sArraySize := 1\n", bindName)
-	res += pad(depth) + fmt.Sprintf("	if %s.Fields[%sFieldIndex].Field.Array {\n", bindName, bindName)
-	res += emitReadI32(depth + 2)
-	res += pad(depth) + fmt.Sprintf("		%sArraySize = int(v32_)\n", bindName)
+	res += fmt.Sprintf("for %sFieldIndex := 0; %sFieldIndex < len(%s.Fields); %sFieldIndex++ {\n", bindName, bindName, bindName, bindName)
+	res += fmt.Sprintf("	%sArraySize := 1\n", bindName)
+	res += fmt.Sprintf("	if %s.Fields[%sFieldIndex].Field.Array {\n", bindName, bindName)
+	res += emitReadI32()
+	res += fmt.Sprintf("		%sArraySize = int(v32_)\n", bindName)
 	if len(complexFields) > 0 {
-		res += pad(depth) + fmt.Sprintf("		if %s.Fields[%sFieldIndex].Field.Type == typeMap.%s {\n", bindName, bindName, TypeID2Sym(complexFields[0].Type))
-		res += pad(depth) + fmt.Sprintf("			*%s.Fields[%sFieldIndex].%s = make([]%s, 0, %sArraySize)\n",
+		res += fmt.Sprintf("		if %s.Fields[%sFieldIndex].Field.Type == typeMap.%s {\n", bindName, bindName, TypeID2Sym(complexFields[0].Type))
+		res += fmt.Sprintf("			*%s.Fields[%sFieldIndex].%s = make([]%s, 0, %sArraySize)\n",
 			bindName, bindName, name(TypeForCPoolID(complexFields[0].Type)), name(TypeForCPoolID(complexFields[0].Type)), bindName)
-		res += pad(depth) + fmt.Sprintf("		}\n")
+		res += fmt.Sprintf("		}\n")
 	}
-	res += pad(depth) + fmt.Sprintf("	}\n")
-	res += pad(depth) + fmt.Sprintf("	for %sArrayIndex := 0; %sArrayIndex < %sArraySize; %sArrayIndex++ {\n", bindName, bindName, bindName, bindName)
-	res += pad(depth) + fmt.Sprintf("	if %s.Fields[%sFieldIndex].Field.ConstantPool {\n", bindName, bindName)
-	res += emitReadI32(depth + 2)
+	res += fmt.Sprintf("	}\n")
+	res += fmt.Sprintf("	for %sArrayIndex := 0; %sArrayIndex < %sArraySize; %sArrayIndex++ {\n", bindName, bindName, bindName, bindName)
+	res += fmt.Sprintf("	if %s.Fields[%sFieldIndex].Field.ConstantPool {\n", bindName, bindName)
+	res += emitReadI32()
 	if len(cpoolFields) > 0 {
-		res += pad(depth) + fmt.Sprintf("		switch %s.Fields[%sFieldIndex].Field.Type {\n", bindName, bindName)
+		res += fmt.Sprintf("		switch %s.Fields[%sFieldIndex].Field.Type {\n", bindName, bindName)
 		for _, field := range cpoolFields {
-			res += pad(depth) + fmt.Sprintf("		case typeMap.%s:\n", TypeID2Sym(field.Type))
-			res += pad(depth) + fmt.Sprintf("			if %s.Fields[%sFieldIndex].%s != nil {\n", bindName, bindName, goTypeName(field))
-			res += pad(depth) + fmt.Sprintf("				*%s.Fields[%sFieldIndex].%s = %s(v32_)\n", bindName, bindName, goTypeName(field), goTypeName(field))
-			res += pad(depth) + fmt.Sprintf("			}\n")
+			res += fmt.Sprintf("		case typeMap.%s:\n", TypeID2Sym(field.Type))
+			res += fmt.Sprintf("			if %s.Fields[%sFieldIndex].%s != nil {\n", bindName, bindName, goTypeName(field))
+			res += fmt.Sprintf("				*%s.Fields[%sFieldIndex].%s = %s(v32_)\n", bindName, bindName, goTypeName(field), goTypeName(field))
+			res += fmt.Sprintf("			}\n")
 		}
-		res += pad(depth) + fmt.Sprintf("		}\n")
+		res += fmt.Sprintf("		}\n")
 	}
-	res += pad(depth) + fmt.Sprintf("	} else {\n")
-	res += pad(depth) + fmt.Sprintf("		%sFieldTypeID := %s.Fields[%sFieldIndex].Field.Type\n", bindName, bindName, bindName)
+	res += fmt.Sprintf("	} else {\n")
+	res += fmt.Sprintf("		%sFieldTypeID := %s.Fields[%sFieldIndex].Field.Type\n", bindName, bindName, bindName)
 
-	res += pad(depth) + fmt.Sprintf("		switch %sFieldTypeID {\n", bindName)
-	res += pad(depth) + fmt.Sprintf("		case  typeMap.T_STRING:\n")
-	res += emitString(depth + 3)
+	res += fmt.Sprintf("		switch %sFieldTypeID {\n", bindName)
+	res += fmt.Sprintf("		case  typeMap.T_STRING:\n")
+	res += emitString()
 	if fieldsHas(fs, T_STRING) {
-		res += pad(depth) + fmt.Sprintf("			if %s.Fields[%sFieldIndex].string != nil {\n", bindName, bindName)
-		res += pad(depth) + fmt.Sprintf("				*%s.Fields[%sFieldIndex].string = s_\n", bindName, bindName)
-		res += pad(depth) + fmt.Sprintf("			}\n")
+		res += fmt.Sprintf("			if %s.Fields[%sFieldIndex].string != nil {\n", bindName, bindName)
+		res += fmt.Sprintf("				*%s.Fields[%sFieldIndex].string = s_\n", bindName, bindName)
+		res += fmt.Sprintf("			}\n")
 	} else {
-		res += pad(depth) + fmt.Sprintf("			// skipping\n")
+		res += fmt.Sprintf("			// skipping\n")
 	}
 
-	res += pad(depth) + fmt.Sprintf("		case typeMap.T_INT:\n")
-	res += emitReadI32(depth + 3)
+	res += fmt.Sprintf("		case typeMap.T_INT:\n")
+	res += emitReadI32()
 	if fieldsHas(fs, T_INT) {
-		res += pad(depth) + fmt.Sprintf("			if %s.Fields[%sFieldIndex].uint32 != nil {\n", bindName, bindName)
-		res += pad(depth) + fmt.Sprintf("				*%s.Fields[%sFieldIndex].uint32 = v32_\n", bindName, bindName)
-		res += pad(depth) + fmt.Sprintf("			}\n")
+		res += fmt.Sprintf("			if %s.Fields[%sFieldIndex].uint32 != nil {\n", bindName, bindName)
+		res += fmt.Sprintf("				*%s.Fields[%sFieldIndex].uint32 = v32_\n", bindName, bindName)
+		res += fmt.Sprintf("			}\n")
 	} else {
-		res += pad(depth) + fmt.Sprintf("			// skipping\n")
+		res += fmt.Sprintf("			// skipping\n")
 	}
-	res += pad(depth) + fmt.Sprintf("		case typeMap.T_LONG:\n")
-	res += emitReadU64(depth + 3)
+	res += fmt.Sprintf("		case typeMap.T_LONG:\n")
+	res += emitReadU64()
 	if fieldsHas(fs, T_LONG) {
-		res += pad(depth) + fmt.Sprintf("			if %s.Fields[%sFieldIndex].uint64 != nil {\n", bindName, bindName)
-		res += pad(depth) + fmt.Sprintf("				*%s.Fields[%sFieldIndex].uint64 = v64_\n", bindName, bindName)
-		res += pad(depth) + fmt.Sprintf("			}\n")
+		res += fmt.Sprintf("			if %s.Fields[%sFieldIndex].uint64 != nil {\n", bindName, bindName)
+		res += fmt.Sprintf("				*%s.Fields[%sFieldIndex].uint64 = v64_\n", bindName, bindName)
+		res += fmt.Sprintf("			}\n")
 	} else {
-		res += pad(depth) + fmt.Sprintf("			// skipping\n")
+		res += fmt.Sprintf("			// skipping\n")
 	}
 
-	res += pad(depth) + fmt.Sprintf("		case typeMap.T_BOOLEAN:\n")
-	res += emitReadByte(depth + 3)
+	res += fmt.Sprintf("		case typeMap.T_BOOLEAN:\n")
+	res += emitReadByte()
 	if fieldsHas(fs, T_BOOLEAN) {
-		res += pad(depth) + fmt.Sprintf("			if %s.Fields[%sFieldIndex].bool != nil {\n", bindName, bindName)
-		res += pad(depth) + fmt.Sprintf("				*%s.Fields[%sFieldIndex].bool = b_ != 0\n", bindName, bindName)
-		res += pad(depth) + fmt.Sprintf("			}\n")
+		res += fmt.Sprintf("			if %s.Fields[%sFieldIndex].bool != nil {\n", bindName, bindName)
+		res += fmt.Sprintf("				*%s.Fields[%sFieldIndex].bool = b_ != 0\n", bindName, bindName)
+		res += fmt.Sprintf("			}\n")
 	} else {
-		res += pad(depth) + fmt.Sprintf("			// skipping\n")
+		res += fmt.Sprintf("			// skipping\n")
 	}
-	res += pad(depth) + fmt.Sprintf("		case typeMap.T_FLOAT:\n")
-	res += emitReadI32(depth + 3)
+	res += fmt.Sprintf("		case typeMap.T_FLOAT:\n")
+	res += emitReadI32()
 	if fieldsHas(fs, T_FLOAT) {
-		res += pad(depth) + fmt.Sprintf("			if %s.Fields[%sFieldIndex].float32 != nil {\n", bindName, bindName)
-		res += pad(depth) + fmt.Sprintf("				*%s.Fields[%sFieldIndex].float32 = *(*float32)(unsafe.Pointer(&v32_))\n", bindName, bindName)
-		res += pad(depth) + fmt.Sprintf("			}\n")
+		res += fmt.Sprintf("			if %s.Fields[%sFieldIndex].float32 != nil {\n", bindName, bindName)
+		res += fmt.Sprintf("				*%s.Fields[%sFieldIndex].float32 = *(*float32)(unsafe.Pointer(&v32_))\n", bindName, bindName)
+		res += fmt.Sprintf("			}\n")
 	} else {
-		res += pad(depth) + fmt.Sprintf("			// skipping\n")
+		res += fmt.Sprintf("			// skipping\n")
 	}
 	if nestedAllowed {
 		for _, field := range complexFields {
 			nestedType := TypeForCPoolID(field.Type)
-			res += pad(depth) + fmt.Sprintf("		case typeMap.%s:\n", TypeID2Sym(field.Type))
-			res += generateBindLoop(nestedType, "bind"+name(nestedType), depth+3, false)
+			res += fmt.Sprintf("		case typeMap.%s:\n", TypeID2Sym(field.Type))
+			res += generateBindLoop(nestedType, "bind"+name(nestedType), false)
 			if field.Array {
-				res += pad(depth) + fmt.Sprintf("			if %s.Fields[%sFieldIndex].%s != nil {\n", bindName, bindName, name(nestedType))
-				res += pad(depth) + fmt.Sprintf("				*%s.Fields[%sFieldIndex].%s = append(*%s.Fields[%sFieldIndex].%s, bind%s.Temp)\n", bindName, bindName, name(nestedType), bindName, bindName, name(nestedType), name(nestedType))
-				res += pad(depth) + fmt.Sprintf("			}\n")
+				res += fmt.Sprintf("			if %s.Fields[%sFieldIndex].%s != nil {\n", bindName, bindName, name(nestedType))
+				res += fmt.Sprintf("				*%s.Fields[%sFieldIndex].%s = append(*%s.Fields[%sFieldIndex].%s, bind%s.Temp)\n", bindName, bindName, name(nestedType), bindName, bindName, name(nestedType), name(nestedType))
+				res += fmt.Sprintf("			}\n")
 			} else {
 				panic("TODO " + field.String())
 			}
 		}
 	}
-	res += pad(depth) + fmt.Sprintf("		default:\n")
+	res += fmt.Sprintf("		default:\n")
 	//todo array
-	res += pad(depth) + fmt.Sprintf("			%sFieldType := typeMap.IDMap[%s.Fields[%sFieldIndex].Field.Type]\n", bindName, bindName, bindName)
-	res += pad(depth) + fmt.Sprintf("			if %sFieldType == nil || len(%sFieldType.Fields) == 0 {\n", bindName, bindName)
-	res += pad(depth) + fmt.Sprintf("				return 0, fmt.Errorf(\"unknown type %%d\", %s.Fields[%sFieldIndex].Field.Type)\n", bindName, bindName)
-	res += pad(depth) + fmt.Sprintf("			}\n")
-	res += pad(depth) + fmt.Sprintf("			%sSkipObjects := 1\n", bindName)
-	res += pad(depth) + fmt.Sprintf("			if %s.Fields[%sFieldIndex].Field.Array {\n", bindName, bindName)
-	res += emitReadI32(depth + 4)
-	res += pad(depth) + fmt.Sprintf("				%sSkipObjects = int(v32_)\n", bindName)
-	res += pad(depth) + fmt.Sprintf("			}\n")
-	res += pad(depth) + fmt.Sprintf("			for %sSkipObjectIndex := 0; %sSkipObjectIndex < %sSkipObjects; %sSkipObjectIndex++ {\n", bindName, bindName, bindName, bindName)
-	res += pad(depth) + fmt.Sprintf("				for %sskipFieldIndex := 0; %sskipFieldIndex < len(%sFieldType.Fields); %sskipFieldIndex++ {\n", bindName, bindName, bindName, bindName)
-	res += pad(depth) + fmt.Sprintf("					%sSkipFieldType :=  %sFieldType.Fields[%sskipFieldIndex].Type\n", bindName, bindName, bindName)
-	res += pad(depth) + fmt.Sprintf("					if %sFieldType.Fields[%sskipFieldIndex].ConstantPool {\n", bindName, bindName)
-	res += emitReadI32(depth + 7)
-	res += pad(depth) + fmt.Sprintf("					} else if %sSkipFieldType == typeMap.T_STRING{\n", bindName)
-	res += emitString(depth + 7)
-	res += pad(depth) + fmt.Sprintf("					} else if %sSkipFieldType == typeMap.T_INT {\n", bindName)
-	res += emitReadI32(depth + 7)
-	res += pad(depth) + fmt.Sprintf("					} else if %sSkipFieldType == typeMap.T_FLOAT {\n", bindName)
-	res += emitReadI32(depth + 7)
-	res += pad(depth) + fmt.Sprintf("					} else if %sSkipFieldType == typeMap.T_LONG {\n", bindName)
-	res += emitReadU64(depth + 7)
-	res += pad(depth) + fmt.Sprintf("					} else if %sSkipFieldType == typeMap.T_BOOLEAN {\n", bindName)
-	res += emitReadByte(depth + 7)
-	res += pad(depth) + fmt.Sprintf("					} else {\n")
-	res += pad(depth) + fmt.Sprintf("							return 0, fmt.Errorf(\"nested objects not implemented. \")\n")
-	res += pad(depth) + fmt.Sprintf("					}\n")
-	res += pad(depth) + fmt.Sprintf("				}\n")
-	res += pad(depth) + fmt.Sprintf("			}\n")
-	res += pad(depth) + fmt.Sprintf("			}\n")
-	res += pad(depth) + fmt.Sprintf("		}\n")
-	res += pad(depth) + fmt.Sprintf("	}\n")
-	res += pad(depth) + fmt.Sprintf("}\n")
+	res += fmt.Sprintf("			%sFieldType := typeMap.IDMap[%s.Fields[%sFieldIndex].Field.Type]\n", bindName, bindName, bindName)
+	res += fmt.Sprintf("			if %sFieldType == nil || len(%sFieldType.Fields) == 0 {\n", bindName, bindName)
+	res += fmt.Sprintf("				return 0, fmt.Errorf(\"unknown type %%d\", %s.Fields[%sFieldIndex].Field.Type)\n", bindName, bindName)
+	res += fmt.Sprintf("			}\n")
+	res += fmt.Sprintf("			%sSkipObjects := 1\n", bindName)
+	res += fmt.Sprintf("			if %s.Fields[%sFieldIndex].Field.Array {\n", bindName, bindName)
+	res += emitReadI32()
+	res += fmt.Sprintf("				%sSkipObjects = int(v32_)\n", bindName)
+	res += fmt.Sprintf("			}\n")
+	res += fmt.Sprintf("			for %sSkipObjectIndex := 0; %sSkipObjectIndex < %sSkipObjects; %sSkipObjectIndex++ {\n", bindName, bindName, bindName, bindName)
+	res += fmt.Sprintf("				for %sskipFieldIndex := 0; %sskipFieldIndex < len(%sFieldType.Fields); %sskipFieldIndex++ {\n", bindName, bindName, bindName, bindName)
+	res += fmt.Sprintf("					%sSkipFieldType :=  %sFieldType.Fields[%sskipFieldIndex].Type\n", bindName, bindName, bindName)
+	res += fmt.Sprintf("					if %sFieldType.Fields[%sskipFieldIndex].ConstantPool {\n", bindName, bindName)
+	res += emitReadI32()
+	res += fmt.Sprintf("					} else if %sSkipFieldType == typeMap.T_STRING{\n", bindName)
+	res += emitString()
+	res += fmt.Sprintf("					} else if %sSkipFieldType == typeMap.T_INT {\n", bindName)
+	res += emitReadI32()
+	res += fmt.Sprintf("					} else if %sSkipFieldType == typeMap.T_FLOAT {\n", bindName)
+	res += emitReadI32()
+	res += fmt.Sprintf("					} else if %sSkipFieldType == typeMap.T_LONG {\n", bindName)
+	res += emitReadU64()
+	res += fmt.Sprintf("					} else if %sSkipFieldType == typeMap.T_BOOLEAN {\n", bindName)
+	res += emitReadByte()
+	res += fmt.Sprintf("					} else {\n")
+	res += fmt.Sprintf("							return 0, fmt.Errorf(\"nested objects not implemented. \")\n")
+	res += fmt.Sprintf("					}\n")
+	res += fmt.Sprintf("				}\n")
+	res += fmt.Sprintf("			}\n")
+	res += fmt.Sprintf("			}\n")
+	res += fmt.Sprintf("		}\n")
+	res += fmt.Sprintf("	}\n")
+	res += fmt.Sprintf("}\n")
 	return res
 }
 
@@ -498,85 +495,85 @@ func generateBinding(typ *def.Class, opt options) string {
 	return res
 }
 
-func emitString(depth int) string {
-	res := pad(depth) + "s_ = \"\"\n"
-	res += pad(depth) + "if pos >= l {\n"
-	res += pad(depth) + "	return 0, io.ErrUnexpectedEOF\n"
-	res += pad(depth) + "}\n"
-	res += pad(depth) + "b_ = data[pos]\n"
-	res += pad(depth) + "pos++\n"
-	res += pad(depth) + "switch b_ {\n"
-	res += pad(depth) + "case 0:\n"
-	res += pad(depth) + "	break\n"
-	res += pad(depth) + "case 1:\n"
-	res += pad(depth) + "	break\n"
-	res += pad(depth) + "case 3:\n"
-	res += emitReadI32(depth + 1)
-	res += pad(depth) + "	if pos+int(v32_) > l {\n"
-	res += pad(depth) + "		return 0, io.ErrUnexpectedEOF\n"
-	res += pad(depth) + "	}\n"
+func emitString() string {
+	res := "s_ = \"\"\n"
+	res += "if pos >= l {\n"
+	res += "	return 0, io.ErrUnexpectedEOF\n"
+	res += "}\n"
+	res += "b_ = data[pos]\n"
+	res += "pos++\n"
+	res += "switch b_ {\n"
+	res += "case 0:\n"
+	res += "	break\n"
+	res += "case 1:\n"
+	res += "	break\n"
+	res += "case 3:\n"
+	res += emitReadI32()
+	res += "	if pos+int(v32_) > l {\n"
+	res += "		return 0, io.ErrUnexpectedEOF\n"
+	res += "	}\n"
 
-	res += pad(depth) + "	bs := data[pos : pos+int(v32_)]\n"
-	res += pad(depth) + fmt.Sprintf("	s_ = *(*string)(unsafe.Pointer(&bs))\n")
+	res += "	bs := data[pos : pos+int(v32_)]\n"
+	res += fmt.Sprintf("	s_ = *(*string)(unsafe.Pointer(&bs))\n")
 
-	res += pad(depth) + "	pos += int(v32_)\n"
-	res += pad(depth) + "default:\n"
-	res += pad(depth) + "	return 0, fmt.Errorf(\"unknown string type %d at %d\", b_, pos)\n"
-	res += pad(depth) + "}\n"
+	res += "	pos += int(v32_)\n"
+	res += "default:\n"
+	res += "	return 0, fmt.Errorf(\"unknown string type %d at %d\", b_, pos)\n"
+	res += "}\n"
 	return res
 }
 
-func emitReadByte(depth int) string {
+func emitReadByte() string {
 	code := ""
-	code += pad(depth) + "if pos >= l {\n"
-	code += pad(depth) + "	return 0, io.ErrUnexpectedEOF\n"
-	code += pad(depth) + "}\n"
-	code += pad(depth) + "b_ = data[pos]\n"
-	code += pad(depth) + "pos++\n"
+	code += "if pos >= l {\n"
+	code += "	return 0, io.ErrUnexpectedEOF\n"
+	code += "}\n"
+	code += "b_ = data[pos]\n"
+	code += "pos++\n"
 	return code
 
 }
-func emitReadI32(depth int) string {
+func emitReadI32() string {
 	code := ""
-	code += pad(depth) + "v32_ = uint32(0)\n"
-	code += pad(depth) + "for shift = uint(0); ; shift += 7 {\n"
-	code += pad(depth) + "	if shift >= 32 {\n"
-	code += pad(depth) + "		return 0, def.ErrIntOverflow\n"
-	code += pad(depth) + "	}\n"
-	code += pad(depth) + "	if pos >= l {\n"
-	code += pad(depth) + "		return 0, io.ErrUnexpectedEOF\n"
-	code += pad(depth) + "	}\n"
-	code += pad(depth) + "	b_ = data[pos]\n"
-	code += pad(depth) + "	pos++\n"
-	code += pad(depth) + "	v32_ |= uint32(b_&0x7F) << shift\n"
-	code += pad(depth) + "	if b_ < 0x80 {\n"
-	code += pad(depth) + "		break\n"
-	code += pad(depth) + "	}\n"
-	code += pad(depth) + "}\n"
+	code += "v32_ = uint32(0)\n"
+	code += "for shift = uint(0); ; shift += 7 {\n"
+	code += "	if shift >= 32 {\n"
+	code += "		return 0, def.ErrIntOverflow\n"
+	code += "	}\n"
+	code += "	if pos >= l {\n"
+	code += "		return 0, io.ErrUnexpectedEOF\n"
+	code += "	}\n"
+	code += "	b_ = data[pos]\n"
+	code += "	pos++\n"
+	code += "	v32_ |= uint32(b_&0x7F) << shift\n"
+	code += "	if b_ < 0x80 {\n"
+	code += "		break\n"
+	code += "	}\n"
+	code += "}\n"
 
 	return code
 }
 
-func emitReadU64(depth int) string {
+func emitReadU64() string {
 	code := ""
 
-	code += pad(depth) + "v64_ = 0 \n"
-	code += pad(depth) + "for shift = uint(0); shift <= 56 ; shift += 7 {\n"
-	code += pad(depth) + "	if pos >= l {\n"
-	code += pad(depth) + "		return 0, io.ErrUnexpectedEOF\n"
-	code += pad(depth) + "	}\n"
-	code += pad(depth) + "	b_ = data[pos]\n"
-	code += pad(depth) + "	pos++\n"
-	code += pad(depth) + "	if shift == 56{\n"
-	code += pad(depth) + "		v64_ |= uint64(b_&0xFF) << shift\n"
-	code += pad(depth) + "		break\n"
-	code += pad(depth) + "	} else {\n"
-	code += pad(depth) + "		v64_ |= uint64(b_&0x7F) << shift\n"
-	code += pad(depth) + "		if b_ < 0x80 {\n"
-	code += pad(depth) + "			break\n"
-	code += pad(depth) + "		}\n"
-	code += pad(depth) + "	}\n"
-	code += pad(depth) + "}\n"
+	code += "v64_ = 0 \n"
+	code += "for shift = uint(0); shift <= 56 ; shift += 7 {\n"
+	code += "	if pos >= l {\n"
+	code += "		return 0, io.ErrUnexpectedEOF\n"
+	code += "	}\n"
+	code += "	b_ = data[pos]\n"
+	code += "	pos++\n"
+	code += "	if shift == 56{\n"
+	code += "		v64_ |= uint64(b_&0xFF) << shift\n"
+	code += "		break\n"
+	code += "	} else {\n"
+	code += "		v64_ |= uint64(b_&0x7F) << shift\n"
+	code += "		if b_ < 0x80 {\n"
+	code += "			break\n"
+	code += "		}\n"
+	code += "	}\n"
+	code += "}\n"
 
 	return code
 }
@@ -626,12 +623,4 @@ func listName(typ *def.Class) string {
 
 func capitalize(s string) string {
 	return strings.ToUpper(s[:1]) + s[1:]
-}
-
-func pad(n int) string {
-	res := ""
-	for i := 0; i < n; i++ {
-		res += "\t"
-	}
-	return res
 }

--- a/parser/types/active_settings.go
+++ b/parser/types/active_settings.go
@@ -4,9 +4,9 @@ package types
 
 import (
 	"fmt"
+
 	"github.com/grafana/jfr-parser/parser/types/def"
-	"io"
-	"unsafe"
+	"github.com/grafana/jfr-parser/util"
 )
 
 type BindActiveSetting struct {
@@ -87,54 +87,27 @@ type ActiveSetting struct {
 }
 
 func (this *ActiveSetting) Parse(data []byte, bind *BindActiveSetting, typeMap *def.TypeMap) (pos int, err error) {
-	var (
-		v64_  uint64
-		v32_  uint32
-		s_    string
-		b_    byte
-		shift = uint(0)
-		l     = len(data)
-	)
-	_ = v64_
-	_ = v32_
-	_ = s_
 	for bindFieldIndex := 0; bindFieldIndex < len(bind.Fields); bindFieldIndex++ {
 		bindArraySize := 1
 		if bind.Fields[bindFieldIndex].Field.Array {
-			v32_ = uint32(0)
-			for shift = uint(0); ; shift += 7 {
-				if shift >= 32 {
-					return 0, def.ErrIntOverflow
-				}
-				if pos >= l {
-					return 0, io.ErrUnexpectedEOF
-				}
-				b_ = data[pos]
-				pos++
-				v32_ |= uint32(b_&0x7F) << shift
-				if b_ < 0x80 {
-					break
-				}
+
+			v32_, err := util.ParseVarInt(data, &pos)
+			if err != nil {
+				return 0, err
 			}
+			_ = v32_
+
 			bindArraySize = int(v32_)
 		}
 		for bindArrayIndex := 0; bindArrayIndex < bindArraySize; bindArrayIndex++ {
 			if bind.Fields[bindFieldIndex].Field.ConstantPool {
-				v32_ = uint32(0)
-				for shift = uint(0); ; shift += 7 {
-					if shift >= 32 {
-						return 0, def.ErrIntOverflow
-					}
-					if pos >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b_ = data[pos]
-					pos++
-					v32_ |= uint32(b_&0x7F) << shift
-					if b_ < 0x80 {
-						break
-					}
+
+				v32_, err := util.ParseVarInt(data, &pos)
+				if err != nil {
+					return 0, err
 				}
+				_ = v32_
+
 				switch bind.Fields[bindFieldIndex].Field.Type {
 				case typeMap.T_THREAD:
 					if bind.Fields[bindFieldIndex].ThreadRef != nil {
@@ -149,106 +122,53 @@ func (this *ActiveSetting) Parse(data []byte, bind *BindActiveSetting, typeMap *
 				bindFieldTypeID := bind.Fields[bindFieldIndex].Field.Type
 				switch bindFieldTypeID {
 				case typeMap.T_STRING:
-					s_ = ""
-					if pos >= l {
-						return 0, io.ErrUnexpectedEOF
+
+					s_, err := util.ParseString(data, &pos)
+					if err != nil {
+						return 0, err
 					}
-					b_ = data[pos]
-					pos++
-					switch b_ {
-					case 0:
-						break
-					case 1:
-						break
-					case 3:
-						v32_ = uint32(0)
-						for shift = uint(0); ; shift += 7 {
-							if shift >= 32 {
-								return 0, def.ErrIntOverflow
-							}
-							if pos >= l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							b_ = data[pos]
-							pos++
-							v32_ |= uint32(b_&0x7F) << shift
-							if b_ < 0x80 {
-								break
-							}
-						}
-						if pos+int(v32_) > l {
-							return 0, io.ErrUnexpectedEOF
-						}
-						bs := data[pos : pos+int(v32_)]
-						s_ = *(*string)(unsafe.Pointer(&bs))
-						pos += int(v32_)
-					default:
-						return 0, fmt.Errorf("unknown string type %d at %d", b_, pos)
-					}
+					_ = s_
+
 					if bind.Fields[bindFieldIndex].string != nil {
 						*bind.Fields[bindFieldIndex].string = s_
 					}
 				case typeMap.T_INT:
-					v32_ = uint32(0)
-					for shift = uint(0); ; shift += 7 {
-						if shift >= 32 {
-							return 0, def.ErrIntOverflow
-						}
-						if pos >= l {
-							return 0, io.ErrUnexpectedEOF
-						}
-						b_ = data[pos]
-						pos++
-						v32_ |= uint32(b_&0x7F) << shift
-						if b_ < 0x80 {
-							break
-						}
+
+					v32_, err := util.ParseVarInt(data, &pos)
+					if err != nil {
+						return 0, err
 					}
+					_ = v32_
+
 					// skipping
 				case typeMap.T_LONG:
-					v64_ = 0
-					for shift = uint(0); shift <= 56; shift += 7 {
-						if pos >= l {
-							return 0, io.ErrUnexpectedEOF
-						}
-						b_ = data[pos]
-						pos++
-						if shift == 56 {
-							v64_ |= uint64(b_&0xFF) << shift
-							break
-						} else {
-							v64_ |= uint64(b_&0x7F) << shift
-							if b_ < 0x80 {
-								break
-							}
-						}
+
+					v64_, err := util.ParseVarLong(data, &pos)
+					if err != nil {
+						return 0, err
 					}
+					_ = v64_
+
 					if bind.Fields[bindFieldIndex].uint64 != nil {
 						*bind.Fields[bindFieldIndex].uint64 = v64_
 					}
 				case typeMap.T_BOOLEAN:
-					if pos >= l {
-						return 0, io.ErrUnexpectedEOF
+
+					b_, err := util.ParseByte(data, &pos)
+					if err != nil {
+						return 0, err
 					}
-					b_ = data[pos]
-					pos++
+					_ = b_
+
 					// skipping
 				case typeMap.T_FLOAT:
-					v32_ = uint32(0)
-					for shift = uint(0); ; shift += 7 {
-						if shift >= 32 {
-							return 0, def.ErrIntOverflow
-						}
-						if pos >= l {
-							return 0, io.ErrUnexpectedEOF
-						}
-						b_ = data[pos]
-						pos++
-						v32_ |= uint32(b_&0x7F) << shift
-						if b_ < 0x80 {
-							break
-						}
+
+					v32_, err := util.ParseVarInt(data, &pos)
+					if err != nil {
+						return 0, err
 					}
+					_ = v32_
+
 					// skipping
 				default:
 					bindFieldType := typeMap.IDMap[bind.Fields[bindFieldIndex].Field.Type]
@@ -257,135 +177,66 @@ func (this *ActiveSetting) Parse(data []byte, bind *BindActiveSetting, typeMap *
 					}
 					bindSkipObjects := 1
 					if bind.Fields[bindFieldIndex].Field.Array {
-						v32_ = uint32(0)
-						for shift = uint(0); ; shift += 7 {
-							if shift >= 32 {
-								return 0, def.ErrIntOverflow
-							}
-							if pos >= l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							b_ = data[pos]
-							pos++
-							v32_ |= uint32(b_&0x7F) << shift
-							if b_ < 0x80 {
-								break
-							}
+
+						v32_, err := util.ParseVarInt(data, &pos)
+						if err != nil {
+							return 0, err
 						}
+						_ = v32_
+
 						bindSkipObjects = int(v32_)
 					}
 					for bindSkipObjectIndex := 0; bindSkipObjectIndex < bindSkipObjects; bindSkipObjectIndex++ {
 						for bindskipFieldIndex := 0; bindskipFieldIndex < len(bindFieldType.Fields); bindskipFieldIndex++ {
 							bindSkipFieldType := bindFieldType.Fields[bindskipFieldIndex].Type
 							if bindFieldType.Fields[bindskipFieldIndex].ConstantPool {
-								v32_ = uint32(0)
-								for shift = uint(0); ; shift += 7 {
-									if shift >= 32 {
-										return 0, def.ErrIntOverflow
-									}
-									if pos >= l {
-										return 0, io.ErrUnexpectedEOF
-									}
-									b_ = data[pos]
-									pos++
-									v32_ |= uint32(b_&0x7F) << shift
-									if b_ < 0x80 {
-										break
-									}
+
+								v32_, err := util.ParseVarInt(data, &pos)
+								if err != nil {
+									return 0, err
 								}
+								_ = v32_
+
 							} else if bindSkipFieldType == typeMap.T_STRING {
-								s_ = ""
-								if pos >= l {
-									return 0, io.ErrUnexpectedEOF
+
+								s_, err := util.ParseString(data, &pos)
+								if err != nil {
+									return 0, err
 								}
-								b_ = data[pos]
-								pos++
-								switch b_ {
-								case 0:
-									break
-								case 1:
-									break
-								case 3:
-									v32_ = uint32(0)
-									for shift = uint(0); ; shift += 7 {
-										if shift >= 32 {
-											return 0, def.ErrIntOverflow
-										}
-										if pos >= l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										b_ = data[pos]
-										pos++
-										v32_ |= uint32(b_&0x7F) << shift
-										if b_ < 0x80 {
-											break
-										}
-									}
-									if pos+int(v32_) > l {
-										return 0, io.ErrUnexpectedEOF
-									}
-									bs := data[pos : pos+int(v32_)]
-									s_ = *(*string)(unsafe.Pointer(&bs))
-									pos += int(v32_)
-								default:
-									return 0, fmt.Errorf("unknown string type %d at %d", b_, pos)
-								}
+								_ = s_
+
 							} else if bindSkipFieldType == typeMap.T_INT {
-								v32_ = uint32(0)
-								for shift = uint(0); ; shift += 7 {
-									if shift >= 32 {
-										return 0, def.ErrIntOverflow
-									}
-									if pos >= l {
-										return 0, io.ErrUnexpectedEOF
-									}
-									b_ = data[pos]
-									pos++
-									v32_ |= uint32(b_&0x7F) << shift
-									if b_ < 0x80 {
-										break
-									}
+
+								v32_, err := util.ParseVarInt(data, &pos)
+								if err != nil {
+									return 0, err
 								}
+								_ = v32_
+
 							} else if bindSkipFieldType == typeMap.T_FLOAT {
-								v32_ = uint32(0)
-								for shift = uint(0); ; shift += 7 {
-									if shift >= 32 {
-										return 0, def.ErrIntOverflow
-									}
-									if pos >= l {
-										return 0, io.ErrUnexpectedEOF
-									}
-									b_ = data[pos]
-									pos++
-									v32_ |= uint32(b_&0x7F) << shift
-									if b_ < 0x80 {
-										break
-									}
+
+								v32_, err := util.ParseVarInt(data, &pos)
+								if err != nil {
+									return 0, err
 								}
+								_ = v32_
+
 							} else if bindSkipFieldType == typeMap.T_LONG {
-								v64_ = 0
-								for shift = uint(0); shift <= 56; shift += 7 {
-									if pos >= l {
-										return 0, io.ErrUnexpectedEOF
-									}
-									b_ = data[pos]
-									pos++
-									if shift == 56 {
-										v64_ |= uint64(b_&0xFF) << shift
-										break
-									} else {
-										v64_ |= uint64(b_&0x7F) << shift
-										if b_ < 0x80 {
-											break
-										}
-									}
+
+								v64_, err := util.ParseVarLong(data, &pos)
+								if err != nil {
+									return 0, err
 								}
+								_ = v64_
+
 							} else if bindSkipFieldType == typeMap.T_BOOLEAN {
-								if pos >= l {
-									return 0, io.ErrUnexpectedEOF
+
+								b_, err := util.ParseByte(data, &pos)
+								if err != nil {
+									return 0, err
 								}
-								b_ = data[pos]
-								pos++
+								_ = b_
+
 							} else {
 								return 0, fmt.Errorf("nested objects not implemented. ")
 							}

--- a/parser/types/allocation_in_new_tlab.go
+++ b/parser/types/allocation_in_new_tlab.go
@@ -4,9 +4,9 @@ package types
 
 import (
 	"fmt"
+
 	"github.com/grafana/jfr-parser/parser/types/def"
-	"io"
-	"unsafe"
+	"github.com/grafana/jfr-parser/util"
 )
 
 type BindObjectAllocationInNewTLAB struct {
@@ -87,54 +87,27 @@ type ObjectAllocationInNewTLAB struct {
 }
 
 func (this *ObjectAllocationInNewTLAB) Parse(data []byte, bind *BindObjectAllocationInNewTLAB, typeMap *def.TypeMap) (pos int, err error) {
-	var (
-		v64_  uint64
-		v32_  uint32
-		s_    string
-		b_    byte
-		shift = uint(0)
-		l     = len(data)
-	)
-	_ = v64_
-	_ = v32_
-	_ = s_
 	for bindFieldIndex := 0; bindFieldIndex < len(bind.Fields); bindFieldIndex++ {
 		bindArraySize := 1
 		if bind.Fields[bindFieldIndex].Field.Array {
-			v32_ = uint32(0)
-			for shift = uint(0); ; shift += 7 {
-				if shift >= 32 {
-					return 0, def.ErrIntOverflow
-				}
-				if pos >= l {
-					return 0, io.ErrUnexpectedEOF
-				}
-				b_ = data[pos]
-				pos++
-				v32_ |= uint32(b_&0x7F) << shift
-				if b_ < 0x80 {
-					break
-				}
+
+			v32_, err := util.ParseVarInt(data, &pos)
+			if err != nil {
+				return 0, err
 			}
+			_ = v32_
+
 			bindArraySize = int(v32_)
 		}
 		for bindArrayIndex := 0; bindArrayIndex < bindArraySize; bindArrayIndex++ {
 			if bind.Fields[bindFieldIndex].Field.ConstantPool {
-				v32_ = uint32(0)
-				for shift = uint(0); ; shift += 7 {
-					if shift >= 32 {
-						return 0, def.ErrIntOverflow
-					}
-					if pos >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b_ = data[pos]
-					pos++
-					v32_ |= uint32(b_&0x7F) << shift
-					if b_ < 0x80 {
-						break
-					}
+
+				v32_, err := util.ParseVarInt(data, &pos)
+				if err != nil {
+					return 0, err
 				}
+				_ = v32_
+
 				switch bind.Fields[bindFieldIndex].Field.Type {
 				case typeMap.T_THREAD:
 					if bind.Fields[bindFieldIndex].ThreadRef != nil {
@@ -153,104 +126,51 @@ func (this *ObjectAllocationInNewTLAB) Parse(data []byte, bind *BindObjectAlloca
 				bindFieldTypeID := bind.Fields[bindFieldIndex].Field.Type
 				switch bindFieldTypeID {
 				case typeMap.T_STRING:
-					s_ = ""
-					if pos >= l {
-						return 0, io.ErrUnexpectedEOF
+
+					s_, err := util.ParseString(data, &pos)
+					if err != nil {
+						return 0, err
 					}
-					b_ = data[pos]
-					pos++
-					switch b_ {
-					case 0:
-						break
-					case 1:
-						break
-					case 3:
-						v32_ = uint32(0)
-						for shift = uint(0); ; shift += 7 {
-							if shift >= 32 {
-								return 0, def.ErrIntOverflow
-							}
-							if pos >= l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							b_ = data[pos]
-							pos++
-							v32_ |= uint32(b_&0x7F) << shift
-							if b_ < 0x80 {
-								break
-							}
-						}
-						if pos+int(v32_) > l {
-							return 0, io.ErrUnexpectedEOF
-						}
-						bs := data[pos : pos+int(v32_)]
-						s_ = *(*string)(unsafe.Pointer(&bs))
-						pos += int(v32_)
-					default:
-						return 0, fmt.Errorf("unknown string type %d at %d", b_, pos)
-					}
+					_ = s_
+
 					// skipping
 				case typeMap.T_INT:
-					v32_ = uint32(0)
-					for shift = uint(0); ; shift += 7 {
-						if shift >= 32 {
-							return 0, def.ErrIntOverflow
-						}
-						if pos >= l {
-							return 0, io.ErrUnexpectedEOF
-						}
-						b_ = data[pos]
-						pos++
-						v32_ |= uint32(b_&0x7F) << shift
-						if b_ < 0x80 {
-							break
-						}
+
+					v32_, err := util.ParseVarInt(data, &pos)
+					if err != nil {
+						return 0, err
 					}
+					_ = v32_
+
 					// skipping
 				case typeMap.T_LONG:
-					v64_ = 0
-					for shift = uint(0); shift <= 56; shift += 7 {
-						if pos >= l {
-							return 0, io.ErrUnexpectedEOF
-						}
-						b_ = data[pos]
-						pos++
-						if shift == 56 {
-							v64_ |= uint64(b_&0xFF) << shift
-							break
-						} else {
-							v64_ |= uint64(b_&0x7F) << shift
-							if b_ < 0x80 {
-								break
-							}
-						}
+
+					v64_, err := util.ParseVarLong(data, &pos)
+					if err != nil {
+						return 0, err
 					}
+					_ = v64_
+
 					if bind.Fields[bindFieldIndex].uint64 != nil {
 						*bind.Fields[bindFieldIndex].uint64 = v64_
 					}
 				case typeMap.T_BOOLEAN:
-					if pos >= l {
-						return 0, io.ErrUnexpectedEOF
+
+					b_, err := util.ParseByte(data, &pos)
+					if err != nil {
+						return 0, err
 					}
-					b_ = data[pos]
-					pos++
+					_ = b_
+
 					// skipping
 				case typeMap.T_FLOAT:
-					v32_ = uint32(0)
-					for shift = uint(0); ; shift += 7 {
-						if shift >= 32 {
-							return 0, def.ErrIntOverflow
-						}
-						if pos >= l {
-							return 0, io.ErrUnexpectedEOF
-						}
-						b_ = data[pos]
-						pos++
-						v32_ |= uint32(b_&0x7F) << shift
-						if b_ < 0x80 {
-							break
-						}
+
+					v32_, err := util.ParseVarInt(data, &pos)
+					if err != nil {
+						return 0, err
 					}
+					_ = v32_
+
 					// skipping
 				default:
 					bindFieldType := typeMap.IDMap[bind.Fields[bindFieldIndex].Field.Type]
@@ -259,135 +179,66 @@ func (this *ObjectAllocationInNewTLAB) Parse(data []byte, bind *BindObjectAlloca
 					}
 					bindSkipObjects := 1
 					if bind.Fields[bindFieldIndex].Field.Array {
-						v32_ = uint32(0)
-						for shift = uint(0); ; shift += 7 {
-							if shift >= 32 {
-								return 0, def.ErrIntOverflow
-							}
-							if pos >= l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							b_ = data[pos]
-							pos++
-							v32_ |= uint32(b_&0x7F) << shift
-							if b_ < 0x80 {
-								break
-							}
+
+						v32_, err := util.ParseVarInt(data, &pos)
+						if err != nil {
+							return 0, err
 						}
+						_ = v32_
+
 						bindSkipObjects = int(v32_)
 					}
 					for bindSkipObjectIndex := 0; bindSkipObjectIndex < bindSkipObjects; bindSkipObjectIndex++ {
 						for bindskipFieldIndex := 0; bindskipFieldIndex < len(bindFieldType.Fields); bindskipFieldIndex++ {
 							bindSkipFieldType := bindFieldType.Fields[bindskipFieldIndex].Type
 							if bindFieldType.Fields[bindskipFieldIndex].ConstantPool {
-								v32_ = uint32(0)
-								for shift = uint(0); ; shift += 7 {
-									if shift >= 32 {
-										return 0, def.ErrIntOverflow
-									}
-									if pos >= l {
-										return 0, io.ErrUnexpectedEOF
-									}
-									b_ = data[pos]
-									pos++
-									v32_ |= uint32(b_&0x7F) << shift
-									if b_ < 0x80 {
-										break
-									}
+
+								v32_, err := util.ParseVarInt(data, &pos)
+								if err != nil {
+									return 0, err
 								}
+								_ = v32_
+
 							} else if bindSkipFieldType == typeMap.T_STRING {
-								s_ = ""
-								if pos >= l {
-									return 0, io.ErrUnexpectedEOF
+
+								s_, err := util.ParseString(data, &pos)
+								if err != nil {
+									return 0, err
 								}
-								b_ = data[pos]
-								pos++
-								switch b_ {
-								case 0:
-									break
-								case 1:
-									break
-								case 3:
-									v32_ = uint32(0)
-									for shift = uint(0); ; shift += 7 {
-										if shift >= 32 {
-											return 0, def.ErrIntOverflow
-										}
-										if pos >= l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										b_ = data[pos]
-										pos++
-										v32_ |= uint32(b_&0x7F) << shift
-										if b_ < 0x80 {
-											break
-										}
-									}
-									if pos+int(v32_) > l {
-										return 0, io.ErrUnexpectedEOF
-									}
-									bs := data[pos : pos+int(v32_)]
-									s_ = *(*string)(unsafe.Pointer(&bs))
-									pos += int(v32_)
-								default:
-									return 0, fmt.Errorf("unknown string type %d at %d", b_, pos)
-								}
+								_ = s_
+
 							} else if bindSkipFieldType == typeMap.T_INT {
-								v32_ = uint32(0)
-								for shift = uint(0); ; shift += 7 {
-									if shift >= 32 {
-										return 0, def.ErrIntOverflow
-									}
-									if pos >= l {
-										return 0, io.ErrUnexpectedEOF
-									}
-									b_ = data[pos]
-									pos++
-									v32_ |= uint32(b_&0x7F) << shift
-									if b_ < 0x80 {
-										break
-									}
+
+								v32_, err := util.ParseVarInt(data, &pos)
+								if err != nil {
+									return 0, err
 								}
+								_ = v32_
+
 							} else if bindSkipFieldType == typeMap.T_FLOAT {
-								v32_ = uint32(0)
-								for shift = uint(0); ; shift += 7 {
-									if shift >= 32 {
-										return 0, def.ErrIntOverflow
-									}
-									if pos >= l {
-										return 0, io.ErrUnexpectedEOF
-									}
-									b_ = data[pos]
-									pos++
-									v32_ |= uint32(b_&0x7F) << shift
-									if b_ < 0x80 {
-										break
-									}
+
+								v32_, err := util.ParseVarInt(data, &pos)
+								if err != nil {
+									return 0, err
 								}
+								_ = v32_
+
 							} else if bindSkipFieldType == typeMap.T_LONG {
-								v64_ = 0
-								for shift = uint(0); shift <= 56; shift += 7 {
-									if pos >= l {
-										return 0, io.ErrUnexpectedEOF
-									}
-									b_ = data[pos]
-									pos++
-									if shift == 56 {
-										v64_ |= uint64(b_&0xFF) << shift
-										break
-									} else {
-										v64_ |= uint64(b_&0x7F) << shift
-										if b_ < 0x80 {
-											break
-										}
-									}
+
+								v64_, err := util.ParseVarLong(data, &pos)
+								if err != nil {
+									return 0, err
 								}
+								_ = v64_
+
 							} else if bindSkipFieldType == typeMap.T_BOOLEAN {
-								if pos >= l {
-									return 0, io.ErrUnexpectedEOF
+
+								b_, err := util.ParseByte(data, &pos)
+								if err != nil {
+									return 0, err
 								}
-								b_ = data[pos]
-								pos++
+								_ = b_
+
 							} else {
 								return 0, fmt.Errorf("nested objects not implemented. ")
 							}

--- a/parser/types/allocation_outside_tlab.go
+++ b/parser/types/allocation_outside_tlab.go
@@ -4,9 +4,9 @@ package types
 
 import (
 	"fmt"
+
 	"github.com/grafana/jfr-parser/parser/types/def"
-	"io"
-	"unsafe"
+	"github.com/grafana/jfr-parser/util"
 )
 
 type BindObjectAllocationOutsideTLAB struct {
@@ -80,54 +80,27 @@ type ObjectAllocationOutsideTLAB struct {
 }
 
 func (this *ObjectAllocationOutsideTLAB) Parse(data []byte, bind *BindObjectAllocationOutsideTLAB, typeMap *def.TypeMap) (pos int, err error) {
-	var (
-		v64_  uint64
-		v32_  uint32
-		s_    string
-		b_    byte
-		shift = uint(0)
-		l     = len(data)
-	)
-	_ = v64_
-	_ = v32_
-	_ = s_
 	for bindFieldIndex := 0; bindFieldIndex < len(bind.Fields); bindFieldIndex++ {
 		bindArraySize := 1
 		if bind.Fields[bindFieldIndex].Field.Array {
-			v32_ = uint32(0)
-			for shift = uint(0); ; shift += 7 {
-				if shift >= 32 {
-					return 0, def.ErrIntOverflow
-				}
-				if pos >= l {
-					return 0, io.ErrUnexpectedEOF
-				}
-				b_ = data[pos]
-				pos++
-				v32_ |= uint32(b_&0x7F) << shift
-				if b_ < 0x80 {
-					break
-				}
+
+			v32_, err := util.ParseVarInt(data, &pos)
+			if err != nil {
+				return 0, err
 			}
+			_ = v32_
+
 			bindArraySize = int(v32_)
 		}
 		for bindArrayIndex := 0; bindArrayIndex < bindArraySize; bindArrayIndex++ {
 			if bind.Fields[bindFieldIndex].Field.ConstantPool {
-				v32_ = uint32(0)
-				for shift = uint(0); ; shift += 7 {
-					if shift >= 32 {
-						return 0, def.ErrIntOverflow
-					}
-					if pos >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b_ = data[pos]
-					pos++
-					v32_ |= uint32(b_&0x7F) << shift
-					if b_ < 0x80 {
-						break
-					}
+
+				v32_, err := util.ParseVarInt(data, &pos)
+				if err != nil {
+					return 0, err
 				}
+				_ = v32_
+
 				switch bind.Fields[bindFieldIndex].Field.Type {
 				case typeMap.T_THREAD:
 					if bind.Fields[bindFieldIndex].ThreadRef != nil {
@@ -146,104 +119,51 @@ func (this *ObjectAllocationOutsideTLAB) Parse(data []byte, bind *BindObjectAllo
 				bindFieldTypeID := bind.Fields[bindFieldIndex].Field.Type
 				switch bindFieldTypeID {
 				case typeMap.T_STRING:
-					s_ = ""
-					if pos >= l {
-						return 0, io.ErrUnexpectedEOF
+
+					s_, err := util.ParseString(data, &pos)
+					if err != nil {
+						return 0, err
 					}
-					b_ = data[pos]
-					pos++
-					switch b_ {
-					case 0:
-						break
-					case 1:
-						break
-					case 3:
-						v32_ = uint32(0)
-						for shift = uint(0); ; shift += 7 {
-							if shift >= 32 {
-								return 0, def.ErrIntOverflow
-							}
-							if pos >= l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							b_ = data[pos]
-							pos++
-							v32_ |= uint32(b_&0x7F) << shift
-							if b_ < 0x80 {
-								break
-							}
-						}
-						if pos+int(v32_) > l {
-							return 0, io.ErrUnexpectedEOF
-						}
-						bs := data[pos : pos+int(v32_)]
-						s_ = *(*string)(unsafe.Pointer(&bs))
-						pos += int(v32_)
-					default:
-						return 0, fmt.Errorf("unknown string type %d at %d", b_, pos)
-					}
+					_ = s_
+
 					// skipping
 				case typeMap.T_INT:
-					v32_ = uint32(0)
-					for shift = uint(0); ; shift += 7 {
-						if shift >= 32 {
-							return 0, def.ErrIntOverflow
-						}
-						if pos >= l {
-							return 0, io.ErrUnexpectedEOF
-						}
-						b_ = data[pos]
-						pos++
-						v32_ |= uint32(b_&0x7F) << shift
-						if b_ < 0x80 {
-							break
-						}
+
+					v32_, err := util.ParseVarInt(data, &pos)
+					if err != nil {
+						return 0, err
 					}
+					_ = v32_
+
 					// skipping
 				case typeMap.T_LONG:
-					v64_ = 0
-					for shift = uint(0); shift <= 56; shift += 7 {
-						if pos >= l {
-							return 0, io.ErrUnexpectedEOF
-						}
-						b_ = data[pos]
-						pos++
-						if shift == 56 {
-							v64_ |= uint64(b_&0xFF) << shift
-							break
-						} else {
-							v64_ |= uint64(b_&0x7F) << shift
-							if b_ < 0x80 {
-								break
-							}
-						}
+
+					v64_, err := util.ParseVarLong(data, &pos)
+					if err != nil {
+						return 0, err
 					}
+					_ = v64_
+
 					if bind.Fields[bindFieldIndex].uint64 != nil {
 						*bind.Fields[bindFieldIndex].uint64 = v64_
 					}
 				case typeMap.T_BOOLEAN:
-					if pos >= l {
-						return 0, io.ErrUnexpectedEOF
+
+					b_, err := util.ParseByte(data, &pos)
+					if err != nil {
+						return 0, err
 					}
-					b_ = data[pos]
-					pos++
+					_ = b_
+
 					// skipping
 				case typeMap.T_FLOAT:
-					v32_ = uint32(0)
-					for shift = uint(0); ; shift += 7 {
-						if shift >= 32 {
-							return 0, def.ErrIntOverflow
-						}
-						if pos >= l {
-							return 0, io.ErrUnexpectedEOF
-						}
-						b_ = data[pos]
-						pos++
-						v32_ |= uint32(b_&0x7F) << shift
-						if b_ < 0x80 {
-							break
-						}
+
+					v32_, err := util.ParseVarInt(data, &pos)
+					if err != nil {
+						return 0, err
 					}
+					_ = v32_
+
 					// skipping
 				default:
 					bindFieldType := typeMap.IDMap[bind.Fields[bindFieldIndex].Field.Type]
@@ -252,135 +172,66 @@ func (this *ObjectAllocationOutsideTLAB) Parse(data []byte, bind *BindObjectAllo
 					}
 					bindSkipObjects := 1
 					if bind.Fields[bindFieldIndex].Field.Array {
-						v32_ = uint32(0)
-						for shift = uint(0); ; shift += 7 {
-							if shift >= 32 {
-								return 0, def.ErrIntOverflow
-							}
-							if pos >= l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							b_ = data[pos]
-							pos++
-							v32_ |= uint32(b_&0x7F) << shift
-							if b_ < 0x80 {
-								break
-							}
+
+						v32_, err := util.ParseVarInt(data, &pos)
+						if err != nil {
+							return 0, err
 						}
+						_ = v32_
+
 						bindSkipObjects = int(v32_)
 					}
 					for bindSkipObjectIndex := 0; bindSkipObjectIndex < bindSkipObjects; bindSkipObjectIndex++ {
 						for bindskipFieldIndex := 0; bindskipFieldIndex < len(bindFieldType.Fields); bindskipFieldIndex++ {
 							bindSkipFieldType := bindFieldType.Fields[bindskipFieldIndex].Type
 							if bindFieldType.Fields[bindskipFieldIndex].ConstantPool {
-								v32_ = uint32(0)
-								for shift = uint(0); ; shift += 7 {
-									if shift >= 32 {
-										return 0, def.ErrIntOverflow
-									}
-									if pos >= l {
-										return 0, io.ErrUnexpectedEOF
-									}
-									b_ = data[pos]
-									pos++
-									v32_ |= uint32(b_&0x7F) << shift
-									if b_ < 0x80 {
-										break
-									}
+
+								v32_, err := util.ParseVarInt(data, &pos)
+								if err != nil {
+									return 0, err
 								}
+								_ = v32_
+
 							} else if bindSkipFieldType == typeMap.T_STRING {
-								s_ = ""
-								if pos >= l {
-									return 0, io.ErrUnexpectedEOF
+
+								s_, err := util.ParseString(data, &pos)
+								if err != nil {
+									return 0, err
 								}
-								b_ = data[pos]
-								pos++
-								switch b_ {
-								case 0:
-									break
-								case 1:
-									break
-								case 3:
-									v32_ = uint32(0)
-									for shift = uint(0); ; shift += 7 {
-										if shift >= 32 {
-											return 0, def.ErrIntOverflow
-										}
-										if pos >= l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										b_ = data[pos]
-										pos++
-										v32_ |= uint32(b_&0x7F) << shift
-										if b_ < 0x80 {
-											break
-										}
-									}
-									if pos+int(v32_) > l {
-										return 0, io.ErrUnexpectedEOF
-									}
-									bs := data[pos : pos+int(v32_)]
-									s_ = *(*string)(unsafe.Pointer(&bs))
-									pos += int(v32_)
-								default:
-									return 0, fmt.Errorf("unknown string type %d at %d", b_, pos)
-								}
+								_ = s_
+
 							} else if bindSkipFieldType == typeMap.T_INT {
-								v32_ = uint32(0)
-								for shift = uint(0); ; shift += 7 {
-									if shift >= 32 {
-										return 0, def.ErrIntOverflow
-									}
-									if pos >= l {
-										return 0, io.ErrUnexpectedEOF
-									}
-									b_ = data[pos]
-									pos++
-									v32_ |= uint32(b_&0x7F) << shift
-									if b_ < 0x80 {
-										break
-									}
+
+								v32_, err := util.ParseVarInt(data, &pos)
+								if err != nil {
+									return 0, err
 								}
+								_ = v32_
+
 							} else if bindSkipFieldType == typeMap.T_FLOAT {
-								v32_ = uint32(0)
-								for shift = uint(0); ; shift += 7 {
-									if shift >= 32 {
-										return 0, def.ErrIntOverflow
-									}
-									if pos >= l {
-										return 0, io.ErrUnexpectedEOF
-									}
-									b_ = data[pos]
-									pos++
-									v32_ |= uint32(b_&0x7F) << shift
-									if b_ < 0x80 {
-										break
-									}
+
+								v32_, err := util.ParseVarInt(data, &pos)
+								if err != nil {
+									return 0, err
 								}
+								_ = v32_
+
 							} else if bindSkipFieldType == typeMap.T_LONG {
-								v64_ = 0
-								for shift = uint(0); shift <= 56; shift += 7 {
-									if pos >= l {
-										return 0, io.ErrUnexpectedEOF
-									}
-									b_ = data[pos]
-									pos++
-									if shift == 56 {
-										v64_ |= uint64(b_&0xFF) << shift
-										break
-									} else {
-										v64_ |= uint64(b_&0x7F) << shift
-										if b_ < 0x80 {
-											break
-										}
-									}
+
+								v64_, err := util.ParseVarLong(data, &pos)
+								if err != nil {
+									return 0, err
 								}
+								_ = v64_
+
 							} else if bindSkipFieldType == typeMap.T_BOOLEAN {
-								if pos >= l {
-									return 0, io.ErrUnexpectedEOF
+
+								b_, err := util.ParseByte(data, &pos)
+								if err != nil {
+									return 0, err
 								}
-								b_ = data[pos]
-								pos++
+								_ = b_
+
 							} else {
 								return 0, fmt.Errorf("nested objects not implemented. ")
 							}

--- a/parser/types/class.go
+++ b/parser/types/class.go
@@ -4,9 +4,9 @@ package types
 
 import (
 	"fmt"
+
 	"github.com/grafana/jfr-parser/parser/types/def"
-	"io"
-	"unsafe"
+	"github.com/grafana/jfr-parser/util"
 )
 
 type BindClass struct {
@@ -60,89 +60,46 @@ type Class struct {
 }
 
 func (this *ClassList) Parse(data []byte, bind *BindClass, typeMap *def.TypeMap) (pos int, err error) {
-	var (
-		v64_  uint64
-		v32_  uint32
-		s_    string
-		b_    byte
-		shift = uint(0)
-		l     = len(data)
-	)
-	_ = v64_
-	_ = v32_
-	_ = s_
-	v32_ = uint32(0)
-	for shift = uint(0); ; shift += 7 {
-		if shift >= 32 {
-			return 0, def.ErrIntOverflow
-		}
-		if pos >= l {
-			return 0, io.ErrUnexpectedEOF
-		}
-		b_ = data[pos]
-		pos++
-		v32_ |= uint32(b_&0x7F) << shift
-		if b_ < 0x80 {
-			break
-		}
+
+	v32_, err := util.ParseVarInt(data, &pos)
+	if err != nil {
+		return 0, err
 	}
+	_ = v32_
+
 	n := int(v32_)
 	this.IDMap = make(map[ClassRef]uint32, n)
 	this.Class = make([]Class, n)
 	for i := 0; i < n; i++ {
-		v32_ = uint32(0)
-		for shift = uint(0); ; shift += 7 {
-			if shift >= 32 {
-				return 0, def.ErrIntOverflow
-			}
-			if pos >= l {
-				return 0, io.ErrUnexpectedEOF
-			}
-			b_ = data[pos]
-			pos++
-			v32_ |= uint32(b_&0x7F) << shift
-			if b_ < 0x80 {
-				break
-			}
+
+		v32_, err := util.ParseVarInt(data, &pos)
+		if err != nil {
+			return 0, err
 		}
+		_ = v32_
+
 		id := ClassRef(v32_)
 		for bindFieldIndex := 0; bindFieldIndex < len(bind.Fields); bindFieldIndex++ {
 			bindArraySize := 1
 			if bind.Fields[bindFieldIndex].Field.Array {
-				v32_ = uint32(0)
-				for shift = uint(0); ; shift += 7 {
-					if shift >= 32 {
-						return 0, def.ErrIntOverflow
-					}
-					if pos >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b_ = data[pos]
-					pos++
-					v32_ |= uint32(b_&0x7F) << shift
-					if b_ < 0x80 {
-						break
-					}
+
+				v32_, err := util.ParseVarInt(data, &pos)
+				if err != nil {
+					return 0, err
 				}
+				_ = v32_
+
 				bindArraySize = int(v32_)
 			}
 			for bindArrayIndex := 0; bindArrayIndex < bindArraySize; bindArrayIndex++ {
 				if bind.Fields[bindFieldIndex].Field.ConstantPool {
-					v32_ = uint32(0)
-					for shift = uint(0); ; shift += 7 {
-						if shift >= 32 {
-							return 0, def.ErrIntOverflow
-						}
-						if pos >= l {
-							return 0, io.ErrUnexpectedEOF
-						}
-						b_ = data[pos]
-						pos++
-						v32_ |= uint32(b_&0x7F) << shift
-						if b_ < 0x80 {
-							break
-						}
+
+					v32_, err := util.ParseVarInt(data, &pos)
+					if err != nil {
+						return 0, err
 					}
+					_ = v32_
+
 					switch bind.Fields[bindFieldIndex].Field.Type {
 					case typeMap.T_CLASS_LOADER:
 						if bind.Fields[bindFieldIndex].ClassLoaderRef != nil {
@@ -161,104 +118,51 @@ func (this *ClassList) Parse(data []byte, bind *BindClass, typeMap *def.TypeMap)
 					bindFieldTypeID := bind.Fields[bindFieldIndex].Field.Type
 					switch bindFieldTypeID {
 					case typeMap.T_STRING:
-						s_ = ""
-						if pos >= l {
-							return 0, io.ErrUnexpectedEOF
+
+						s_, err := util.ParseString(data, &pos)
+						if err != nil {
+							return 0, err
 						}
-						b_ = data[pos]
-						pos++
-						switch b_ {
-						case 0:
-							break
-						case 1:
-							break
-						case 3:
-							v32_ = uint32(0)
-							for shift = uint(0); ; shift += 7 {
-								if shift >= 32 {
-									return 0, def.ErrIntOverflow
-								}
-								if pos >= l {
-									return 0, io.ErrUnexpectedEOF
-								}
-								b_ = data[pos]
-								pos++
-								v32_ |= uint32(b_&0x7F) << shift
-								if b_ < 0x80 {
-									break
-								}
-							}
-							if pos+int(v32_) > l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							bs := data[pos : pos+int(v32_)]
-							s_ = *(*string)(unsafe.Pointer(&bs))
-							pos += int(v32_)
-						default:
-							return 0, fmt.Errorf("unknown string type %d at %d", b_, pos)
-						}
+						_ = s_
+
 						// skipping
 					case typeMap.T_INT:
-						v32_ = uint32(0)
-						for shift = uint(0); ; shift += 7 {
-							if shift >= 32 {
-								return 0, def.ErrIntOverflow
-							}
-							if pos >= l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							b_ = data[pos]
-							pos++
-							v32_ |= uint32(b_&0x7F) << shift
-							if b_ < 0x80 {
-								break
-							}
+
+						v32_, err := util.ParseVarInt(data, &pos)
+						if err != nil {
+							return 0, err
 						}
+						_ = v32_
+
 						if bind.Fields[bindFieldIndex].uint32 != nil {
 							*bind.Fields[bindFieldIndex].uint32 = v32_
 						}
 					case typeMap.T_LONG:
-						v64_ = 0
-						for shift = uint(0); shift <= 56; shift += 7 {
-							if pos >= l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							b_ = data[pos]
-							pos++
-							if shift == 56 {
-								v64_ |= uint64(b_&0xFF) << shift
-								break
-							} else {
-								v64_ |= uint64(b_&0x7F) << shift
-								if b_ < 0x80 {
-									break
-								}
-							}
+
+						v64_, err := util.ParseVarLong(data, &pos)
+						if err != nil {
+							return 0, err
 						}
+						_ = v64_
+
 						// skipping
 					case typeMap.T_BOOLEAN:
-						if pos >= l {
-							return 0, io.ErrUnexpectedEOF
+
+						b_, err := util.ParseByte(data, &pos)
+						if err != nil {
+							return 0, err
 						}
-						b_ = data[pos]
-						pos++
+						_ = b_
+
 						// skipping
 					case typeMap.T_FLOAT:
-						v32_ = uint32(0)
-						for shift = uint(0); ; shift += 7 {
-							if shift >= 32 {
-								return 0, def.ErrIntOverflow
-							}
-							if pos >= l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							b_ = data[pos]
-							pos++
-							v32_ |= uint32(b_&0x7F) << shift
-							if b_ < 0x80 {
-								break
-							}
+
+						v32_, err := util.ParseVarInt(data, &pos)
+						if err != nil {
+							return 0, err
 						}
+						_ = v32_
+
 						// skipping
 					default:
 						bindFieldType := typeMap.IDMap[bind.Fields[bindFieldIndex].Field.Type]
@@ -267,135 +171,66 @@ func (this *ClassList) Parse(data []byte, bind *BindClass, typeMap *def.TypeMap)
 						}
 						bindSkipObjects := 1
 						if bind.Fields[bindFieldIndex].Field.Array {
-							v32_ = uint32(0)
-							for shift = uint(0); ; shift += 7 {
-								if shift >= 32 {
-									return 0, def.ErrIntOverflow
-								}
-								if pos >= l {
-									return 0, io.ErrUnexpectedEOF
-								}
-								b_ = data[pos]
-								pos++
-								v32_ |= uint32(b_&0x7F) << shift
-								if b_ < 0x80 {
-									break
-								}
+
+							v32_, err := util.ParseVarInt(data, &pos)
+							if err != nil {
+								return 0, err
 							}
+							_ = v32_
+
 							bindSkipObjects = int(v32_)
 						}
 						for bindSkipObjectIndex := 0; bindSkipObjectIndex < bindSkipObjects; bindSkipObjectIndex++ {
 							for bindskipFieldIndex := 0; bindskipFieldIndex < len(bindFieldType.Fields); bindskipFieldIndex++ {
 								bindSkipFieldType := bindFieldType.Fields[bindskipFieldIndex].Type
 								if bindFieldType.Fields[bindskipFieldIndex].ConstantPool {
-									v32_ = uint32(0)
-									for shift = uint(0); ; shift += 7 {
-										if shift >= 32 {
-											return 0, def.ErrIntOverflow
-										}
-										if pos >= l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										b_ = data[pos]
-										pos++
-										v32_ |= uint32(b_&0x7F) << shift
-										if b_ < 0x80 {
-											break
-										}
+
+									v32_, err := util.ParseVarInt(data, &pos)
+									if err != nil {
+										return 0, err
 									}
+									_ = v32_
+
 								} else if bindSkipFieldType == typeMap.T_STRING {
-									s_ = ""
-									if pos >= l {
-										return 0, io.ErrUnexpectedEOF
+
+									s_, err := util.ParseString(data, &pos)
+									if err != nil {
+										return 0, err
 									}
-									b_ = data[pos]
-									pos++
-									switch b_ {
-									case 0:
-										break
-									case 1:
-										break
-									case 3:
-										v32_ = uint32(0)
-										for shift = uint(0); ; shift += 7 {
-											if shift >= 32 {
-												return 0, def.ErrIntOverflow
-											}
-											if pos >= l {
-												return 0, io.ErrUnexpectedEOF
-											}
-											b_ = data[pos]
-											pos++
-											v32_ |= uint32(b_&0x7F) << shift
-											if b_ < 0x80 {
-												break
-											}
-										}
-										if pos+int(v32_) > l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										bs := data[pos : pos+int(v32_)]
-										s_ = *(*string)(unsafe.Pointer(&bs))
-										pos += int(v32_)
-									default:
-										return 0, fmt.Errorf("unknown string type %d at %d", b_, pos)
-									}
+									_ = s_
+
 								} else if bindSkipFieldType == typeMap.T_INT {
-									v32_ = uint32(0)
-									for shift = uint(0); ; shift += 7 {
-										if shift >= 32 {
-											return 0, def.ErrIntOverflow
-										}
-										if pos >= l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										b_ = data[pos]
-										pos++
-										v32_ |= uint32(b_&0x7F) << shift
-										if b_ < 0x80 {
-											break
-										}
+
+									v32_, err := util.ParseVarInt(data, &pos)
+									if err != nil {
+										return 0, err
 									}
+									_ = v32_
+
 								} else if bindSkipFieldType == typeMap.T_FLOAT {
-									v32_ = uint32(0)
-									for shift = uint(0); ; shift += 7 {
-										if shift >= 32 {
-											return 0, def.ErrIntOverflow
-										}
-										if pos >= l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										b_ = data[pos]
-										pos++
-										v32_ |= uint32(b_&0x7F) << shift
-										if b_ < 0x80 {
-											break
-										}
+
+									v32_, err := util.ParseVarInt(data, &pos)
+									if err != nil {
+										return 0, err
 									}
+									_ = v32_
+
 								} else if bindSkipFieldType == typeMap.T_LONG {
-									v64_ = 0
-									for shift = uint(0); shift <= 56; shift += 7 {
-										if pos >= l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										b_ = data[pos]
-										pos++
-										if shift == 56 {
-											v64_ |= uint64(b_&0xFF) << shift
-											break
-										} else {
-											v64_ |= uint64(b_&0x7F) << shift
-											if b_ < 0x80 {
-												break
-											}
-										}
+
+									v64_, err := util.ParseVarLong(data, &pos)
+									if err != nil {
+										return 0, err
 									}
+									_ = v64_
+
 								} else if bindSkipFieldType == typeMap.T_BOOLEAN {
-									if pos >= l {
-										return 0, io.ErrUnexpectedEOF
+
+									b_, err := util.ParseByte(data, &pos)
+									if err != nil {
+										return 0, err
 									}
-									b_ = data[pos]
-									pos++
+									_ = b_
+
 								} else {
 									return 0, fmt.Errorf("nested objects not implemented. ")
 								}

--- a/parser/types/classloader.go
+++ b/parser/types/classloader.go
@@ -4,9 +4,9 @@ package types
 
 import (
 	"fmt"
+
 	"github.com/grafana/jfr-parser/parser/types/def"
-	"io"
-	"unsafe"
+	"github.com/grafana/jfr-parser/util"
 )
 
 type BindClassLoader struct {
@@ -56,89 +56,46 @@ type ClassLoader struct {
 }
 
 func (this *ClassLoaderList) Parse(data []byte, bind *BindClassLoader, typeMap *def.TypeMap) (pos int, err error) {
-	var (
-		v64_  uint64
-		v32_  uint32
-		s_    string
-		b_    byte
-		shift = uint(0)
-		l     = len(data)
-	)
-	_ = v64_
-	_ = v32_
-	_ = s_
-	v32_ = uint32(0)
-	for shift = uint(0); ; shift += 7 {
-		if shift >= 32 {
-			return 0, def.ErrIntOverflow
-		}
-		if pos >= l {
-			return 0, io.ErrUnexpectedEOF
-		}
-		b_ = data[pos]
-		pos++
-		v32_ |= uint32(b_&0x7F) << shift
-		if b_ < 0x80 {
-			break
-		}
+
+	v32_, err := util.ParseVarInt(data, &pos)
+	if err != nil {
+		return 0, err
 	}
+	_ = v32_
+
 	n := int(v32_)
 	this.IDMap = make(map[ClassLoaderRef]uint32, n)
 	this.ClassLoader = make([]ClassLoader, n)
 	for i := 0; i < n; i++ {
-		v32_ = uint32(0)
-		for shift = uint(0); ; shift += 7 {
-			if shift >= 32 {
-				return 0, def.ErrIntOverflow
-			}
-			if pos >= l {
-				return 0, io.ErrUnexpectedEOF
-			}
-			b_ = data[pos]
-			pos++
-			v32_ |= uint32(b_&0x7F) << shift
-			if b_ < 0x80 {
-				break
-			}
+
+		v32_, err := util.ParseVarInt(data, &pos)
+		if err != nil {
+			return 0, err
 		}
+		_ = v32_
+
 		id := ClassLoaderRef(v32_)
 		for bindFieldIndex := 0; bindFieldIndex < len(bind.Fields); bindFieldIndex++ {
 			bindArraySize := 1
 			if bind.Fields[bindFieldIndex].Field.Array {
-				v32_ = uint32(0)
-				for shift = uint(0); ; shift += 7 {
-					if shift >= 32 {
-						return 0, def.ErrIntOverflow
-					}
-					if pos >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b_ = data[pos]
-					pos++
-					v32_ |= uint32(b_&0x7F) << shift
-					if b_ < 0x80 {
-						break
-					}
+
+				v32_, err := util.ParseVarInt(data, &pos)
+				if err != nil {
+					return 0, err
 				}
+				_ = v32_
+
 				bindArraySize = int(v32_)
 			}
 			for bindArrayIndex := 0; bindArrayIndex < bindArraySize; bindArrayIndex++ {
 				if bind.Fields[bindFieldIndex].Field.ConstantPool {
-					v32_ = uint32(0)
-					for shift = uint(0); ; shift += 7 {
-						if shift >= 32 {
-							return 0, def.ErrIntOverflow
-						}
-						if pos >= l {
-							return 0, io.ErrUnexpectedEOF
-						}
-						b_ = data[pos]
-						pos++
-						v32_ |= uint32(b_&0x7F) << shift
-						if b_ < 0x80 {
-							break
-						}
+
+					v32_, err := util.ParseVarInt(data, &pos)
+					if err != nil {
+						return 0, err
 					}
+					_ = v32_
+
 					switch bind.Fields[bindFieldIndex].Field.Type {
 					case typeMap.T_CLASS:
 						if bind.Fields[bindFieldIndex].ClassRef != nil {
@@ -153,102 +110,49 @@ func (this *ClassLoaderList) Parse(data []byte, bind *BindClassLoader, typeMap *
 					bindFieldTypeID := bind.Fields[bindFieldIndex].Field.Type
 					switch bindFieldTypeID {
 					case typeMap.T_STRING:
-						s_ = ""
-						if pos >= l {
-							return 0, io.ErrUnexpectedEOF
+
+						s_, err := util.ParseString(data, &pos)
+						if err != nil {
+							return 0, err
 						}
-						b_ = data[pos]
-						pos++
-						switch b_ {
-						case 0:
-							break
-						case 1:
-							break
-						case 3:
-							v32_ = uint32(0)
-							for shift = uint(0); ; shift += 7 {
-								if shift >= 32 {
-									return 0, def.ErrIntOverflow
-								}
-								if pos >= l {
-									return 0, io.ErrUnexpectedEOF
-								}
-								b_ = data[pos]
-								pos++
-								v32_ |= uint32(b_&0x7F) << shift
-								if b_ < 0x80 {
-									break
-								}
-							}
-							if pos+int(v32_) > l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							bs := data[pos : pos+int(v32_)]
-							s_ = *(*string)(unsafe.Pointer(&bs))
-							pos += int(v32_)
-						default:
-							return 0, fmt.Errorf("unknown string type %d at %d", b_, pos)
-						}
+						_ = s_
+
 						// skipping
 					case typeMap.T_INT:
-						v32_ = uint32(0)
-						for shift = uint(0); ; shift += 7 {
-							if shift >= 32 {
-								return 0, def.ErrIntOverflow
-							}
-							if pos >= l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							b_ = data[pos]
-							pos++
-							v32_ |= uint32(b_&0x7F) << shift
-							if b_ < 0x80 {
-								break
-							}
+
+						v32_, err := util.ParseVarInt(data, &pos)
+						if err != nil {
+							return 0, err
 						}
+						_ = v32_
+
 						// skipping
 					case typeMap.T_LONG:
-						v64_ = 0
-						for shift = uint(0); shift <= 56; shift += 7 {
-							if pos >= l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							b_ = data[pos]
-							pos++
-							if shift == 56 {
-								v64_ |= uint64(b_&0xFF) << shift
-								break
-							} else {
-								v64_ |= uint64(b_&0x7F) << shift
-								if b_ < 0x80 {
-									break
-								}
-							}
+
+						v64_, err := util.ParseVarLong(data, &pos)
+						if err != nil {
+							return 0, err
 						}
+						_ = v64_
+
 						// skipping
 					case typeMap.T_BOOLEAN:
-						if pos >= l {
-							return 0, io.ErrUnexpectedEOF
+
+						b_, err := util.ParseByte(data, &pos)
+						if err != nil {
+							return 0, err
 						}
-						b_ = data[pos]
-						pos++
+						_ = b_
+
 						// skipping
 					case typeMap.T_FLOAT:
-						v32_ = uint32(0)
-						for shift = uint(0); ; shift += 7 {
-							if shift >= 32 {
-								return 0, def.ErrIntOverflow
-							}
-							if pos >= l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							b_ = data[pos]
-							pos++
-							v32_ |= uint32(b_&0x7F) << shift
-							if b_ < 0x80 {
-								break
-							}
+
+						v32_, err := util.ParseVarInt(data, &pos)
+						if err != nil {
+							return 0, err
 						}
+						_ = v32_
+
 						// skipping
 					default:
 						bindFieldType := typeMap.IDMap[bind.Fields[bindFieldIndex].Field.Type]
@@ -257,135 +161,66 @@ func (this *ClassLoaderList) Parse(data []byte, bind *BindClassLoader, typeMap *
 						}
 						bindSkipObjects := 1
 						if bind.Fields[bindFieldIndex].Field.Array {
-							v32_ = uint32(0)
-							for shift = uint(0); ; shift += 7 {
-								if shift >= 32 {
-									return 0, def.ErrIntOverflow
-								}
-								if pos >= l {
-									return 0, io.ErrUnexpectedEOF
-								}
-								b_ = data[pos]
-								pos++
-								v32_ |= uint32(b_&0x7F) << shift
-								if b_ < 0x80 {
-									break
-								}
+
+							v32_, err := util.ParseVarInt(data, &pos)
+							if err != nil {
+								return 0, err
 							}
+							_ = v32_
+
 							bindSkipObjects = int(v32_)
 						}
 						for bindSkipObjectIndex := 0; bindSkipObjectIndex < bindSkipObjects; bindSkipObjectIndex++ {
 							for bindskipFieldIndex := 0; bindskipFieldIndex < len(bindFieldType.Fields); bindskipFieldIndex++ {
 								bindSkipFieldType := bindFieldType.Fields[bindskipFieldIndex].Type
 								if bindFieldType.Fields[bindskipFieldIndex].ConstantPool {
-									v32_ = uint32(0)
-									for shift = uint(0); ; shift += 7 {
-										if shift >= 32 {
-											return 0, def.ErrIntOverflow
-										}
-										if pos >= l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										b_ = data[pos]
-										pos++
-										v32_ |= uint32(b_&0x7F) << shift
-										if b_ < 0x80 {
-											break
-										}
+
+									v32_, err := util.ParseVarInt(data, &pos)
+									if err != nil {
+										return 0, err
 									}
+									_ = v32_
+
 								} else if bindSkipFieldType == typeMap.T_STRING {
-									s_ = ""
-									if pos >= l {
-										return 0, io.ErrUnexpectedEOF
+
+									s_, err := util.ParseString(data, &pos)
+									if err != nil {
+										return 0, err
 									}
-									b_ = data[pos]
-									pos++
-									switch b_ {
-									case 0:
-										break
-									case 1:
-										break
-									case 3:
-										v32_ = uint32(0)
-										for shift = uint(0); ; shift += 7 {
-											if shift >= 32 {
-												return 0, def.ErrIntOverflow
-											}
-											if pos >= l {
-												return 0, io.ErrUnexpectedEOF
-											}
-											b_ = data[pos]
-											pos++
-											v32_ |= uint32(b_&0x7F) << shift
-											if b_ < 0x80 {
-												break
-											}
-										}
-										if pos+int(v32_) > l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										bs := data[pos : pos+int(v32_)]
-										s_ = *(*string)(unsafe.Pointer(&bs))
-										pos += int(v32_)
-									default:
-										return 0, fmt.Errorf("unknown string type %d at %d", b_, pos)
-									}
+									_ = s_
+
 								} else if bindSkipFieldType == typeMap.T_INT {
-									v32_ = uint32(0)
-									for shift = uint(0); ; shift += 7 {
-										if shift >= 32 {
-											return 0, def.ErrIntOverflow
-										}
-										if pos >= l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										b_ = data[pos]
-										pos++
-										v32_ |= uint32(b_&0x7F) << shift
-										if b_ < 0x80 {
-											break
-										}
+
+									v32_, err := util.ParseVarInt(data, &pos)
+									if err != nil {
+										return 0, err
 									}
+									_ = v32_
+
 								} else if bindSkipFieldType == typeMap.T_FLOAT {
-									v32_ = uint32(0)
-									for shift = uint(0); ; shift += 7 {
-										if shift >= 32 {
-											return 0, def.ErrIntOverflow
-										}
-										if pos >= l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										b_ = data[pos]
-										pos++
-										v32_ |= uint32(b_&0x7F) << shift
-										if b_ < 0x80 {
-											break
-										}
+
+									v32_, err := util.ParseVarInt(data, &pos)
+									if err != nil {
+										return 0, err
 									}
+									_ = v32_
+
 								} else if bindSkipFieldType == typeMap.T_LONG {
-									v64_ = 0
-									for shift = uint(0); shift <= 56; shift += 7 {
-										if pos >= l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										b_ = data[pos]
-										pos++
-										if shift == 56 {
-											v64_ |= uint64(b_&0xFF) << shift
-											break
-										} else {
-											v64_ |= uint64(b_&0x7F) << shift
-											if b_ < 0x80 {
-												break
-											}
-										}
+
+									v64_, err := util.ParseVarLong(data, &pos)
+									if err != nil {
+										return 0, err
 									}
+									_ = v64_
+
 								} else if bindSkipFieldType == typeMap.T_BOOLEAN {
-									if pos >= l {
-										return 0, io.ErrUnexpectedEOF
+
+									b_, err := util.ParseByte(data, &pos)
+									if err != nil {
+										return 0, err
 									}
-									b_ = data[pos]
-									pos++
+									_ = b_
+
 								} else {
 									return 0, fmt.Errorf("nested objects not implemented. ")
 								}

--- a/parser/types/execution_sample.go
+++ b/parser/types/execution_sample.go
@@ -4,9 +4,9 @@ package types
 
 import (
 	"fmt"
+
 	"github.com/grafana/jfr-parser/parser/types/def"
-	"io"
-	"unsafe"
+	"github.com/grafana/jfr-parser/util"
 )
 
 type BindExecutionSample struct {
@@ -73,54 +73,27 @@ type ExecutionSample struct {
 }
 
 func (this *ExecutionSample) Parse(data []byte, bind *BindExecutionSample, typeMap *def.TypeMap) (pos int, err error) {
-	var (
-		v64_  uint64
-		v32_  uint32
-		s_    string
-		b_    byte
-		shift = uint(0)
-		l     = len(data)
-	)
-	_ = v64_
-	_ = v32_
-	_ = s_
 	for bindFieldIndex := 0; bindFieldIndex < len(bind.Fields); bindFieldIndex++ {
 		bindArraySize := 1
 		if bind.Fields[bindFieldIndex].Field.Array {
-			v32_ = uint32(0)
-			for shift = uint(0); ; shift += 7 {
-				if shift >= 32 {
-					return 0, def.ErrIntOverflow
-				}
-				if pos >= l {
-					return 0, io.ErrUnexpectedEOF
-				}
-				b_ = data[pos]
-				pos++
-				v32_ |= uint32(b_&0x7F) << shift
-				if b_ < 0x80 {
-					break
-				}
+
+			v32_, err := util.ParseVarInt(data, &pos)
+			if err != nil {
+				return 0, err
 			}
+			_ = v32_
+
 			bindArraySize = int(v32_)
 		}
 		for bindArrayIndex := 0; bindArrayIndex < bindArraySize; bindArrayIndex++ {
 			if bind.Fields[bindFieldIndex].Field.ConstantPool {
-				v32_ = uint32(0)
-				for shift = uint(0); ; shift += 7 {
-					if shift >= 32 {
-						return 0, def.ErrIntOverflow
-					}
-					if pos >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b_ = data[pos]
-					pos++
-					v32_ |= uint32(b_&0x7F) << shift
-					if b_ < 0x80 {
-						break
-					}
+
+				v32_, err := util.ParseVarInt(data, &pos)
+				if err != nil {
+					return 0, err
 				}
+				_ = v32_
+
 				switch bind.Fields[bindFieldIndex].Field.Type {
 				case typeMap.T_THREAD:
 					if bind.Fields[bindFieldIndex].ThreadRef != nil {
@@ -139,104 +112,51 @@ func (this *ExecutionSample) Parse(data []byte, bind *BindExecutionSample, typeM
 				bindFieldTypeID := bind.Fields[bindFieldIndex].Field.Type
 				switch bindFieldTypeID {
 				case typeMap.T_STRING:
-					s_ = ""
-					if pos >= l {
-						return 0, io.ErrUnexpectedEOF
+
+					s_, err := util.ParseString(data, &pos)
+					if err != nil {
+						return 0, err
 					}
-					b_ = data[pos]
-					pos++
-					switch b_ {
-					case 0:
-						break
-					case 1:
-						break
-					case 3:
-						v32_ = uint32(0)
-						for shift = uint(0); ; shift += 7 {
-							if shift >= 32 {
-								return 0, def.ErrIntOverflow
-							}
-							if pos >= l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							b_ = data[pos]
-							pos++
-							v32_ |= uint32(b_&0x7F) << shift
-							if b_ < 0x80 {
-								break
-							}
-						}
-						if pos+int(v32_) > l {
-							return 0, io.ErrUnexpectedEOF
-						}
-						bs := data[pos : pos+int(v32_)]
-						s_ = *(*string)(unsafe.Pointer(&bs))
-						pos += int(v32_)
-					default:
-						return 0, fmt.Errorf("unknown string type %d at %d", b_, pos)
-					}
+					_ = s_
+
 					// skipping
 				case typeMap.T_INT:
-					v32_ = uint32(0)
-					for shift = uint(0); ; shift += 7 {
-						if shift >= 32 {
-							return 0, def.ErrIntOverflow
-						}
-						if pos >= l {
-							return 0, io.ErrUnexpectedEOF
-						}
-						b_ = data[pos]
-						pos++
-						v32_ |= uint32(b_&0x7F) << shift
-						if b_ < 0x80 {
-							break
-						}
+
+					v32_, err := util.ParseVarInt(data, &pos)
+					if err != nil {
+						return 0, err
 					}
+					_ = v32_
+
 					// skipping
 				case typeMap.T_LONG:
-					v64_ = 0
-					for shift = uint(0); shift <= 56; shift += 7 {
-						if pos >= l {
-							return 0, io.ErrUnexpectedEOF
-						}
-						b_ = data[pos]
-						pos++
-						if shift == 56 {
-							v64_ |= uint64(b_&0xFF) << shift
-							break
-						} else {
-							v64_ |= uint64(b_&0x7F) << shift
-							if b_ < 0x80 {
-								break
-							}
-						}
+
+					v64_, err := util.ParseVarLong(data, &pos)
+					if err != nil {
+						return 0, err
 					}
+					_ = v64_
+
 					if bind.Fields[bindFieldIndex].uint64 != nil {
 						*bind.Fields[bindFieldIndex].uint64 = v64_
 					}
 				case typeMap.T_BOOLEAN:
-					if pos >= l {
-						return 0, io.ErrUnexpectedEOF
+
+					b_, err := util.ParseByte(data, &pos)
+					if err != nil {
+						return 0, err
 					}
-					b_ = data[pos]
-					pos++
+					_ = b_
+
 					// skipping
 				case typeMap.T_FLOAT:
-					v32_ = uint32(0)
-					for shift = uint(0); ; shift += 7 {
-						if shift >= 32 {
-							return 0, def.ErrIntOverflow
-						}
-						if pos >= l {
-							return 0, io.ErrUnexpectedEOF
-						}
-						b_ = data[pos]
-						pos++
-						v32_ |= uint32(b_&0x7F) << shift
-						if b_ < 0x80 {
-							break
-						}
+
+					v32_, err := util.ParseVarInt(data, &pos)
+					if err != nil {
+						return 0, err
 					}
+					_ = v32_
+
 					// skipping
 				default:
 					bindFieldType := typeMap.IDMap[bind.Fields[bindFieldIndex].Field.Type]
@@ -245,135 +165,66 @@ func (this *ExecutionSample) Parse(data []byte, bind *BindExecutionSample, typeM
 					}
 					bindSkipObjects := 1
 					if bind.Fields[bindFieldIndex].Field.Array {
-						v32_ = uint32(0)
-						for shift = uint(0); ; shift += 7 {
-							if shift >= 32 {
-								return 0, def.ErrIntOverflow
-							}
-							if pos >= l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							b_ = data[pos]
-							pos++
-							v32_ |= uint32(b_&0x7F) << shift
-							if b_ < 0x80 {
-								break
-							}
+
+						v32_, err := util.ParseVarInt(data, &pos)
+						if err != nil {
+							return 0, err
 						}
+						_ = v32_
+
 						bindSkipObjects = int(v32_)
 					}
 					for bindSkipObjectIndex := 0; bindSkipObjectIndex < bindSkipObjects; bindSkipObjectIndex++ {
 						for bindskipFieldIndex := 0; bindskipFieldIndex < len(bindFieldType.Fields); bindskipFieldIndex++ {
 							bindSkipFieldType := bindFieldType.Fields[bindskipFieldIndex].Type
 							if bindFieldType.Fields[bindskipFieldIndex].ConstantPool {
-								v32_ = uint32(0)
-								for shift = uint(0); ; shift += 7 {
-									if shift >= 32 {
-										return 0, def.ErrIntOverflow
-									}
-									if pos >= l {
-										return 0, io.ErrUnexpectedEOF
-									}
-									b_ = data[pos]
-									pos++
-									v32_ |= uint32(b_&0x7F) << shift
-									if b_ < 0x80 {
-										break
-									}
+
+								v32_, err := util.ParseVarInt(data, &pos)
+								if err != nil {
+									return 0, err
 								}
+								_ = v32_
+
 							} else if bindSkipFieldType == typeMap.T_STRING {
-								s_ = ""
-								if pos >= l {
-									return 0, io.ErrUnexpectedEOF
+
+								s_, err := util.ParseString(data, &pos)
+								if err != nil {
+									return 0, err
 								}
-								b_ = data[pos]
-								pos++
-								switch b_ {
-								case 0:
-									break
-								case 1:
-									break
-								case 3:
-									v32_ = uint32(0)
-									for shift = uint(0); ; shift += 7 {
-										if shift >= 32 {
-											return 0, def.ErrIntOverflow
-										}
-										if pos >= l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										b_ = data[pos]
-										pos++
-										v32_ |= uint32(b_&0x7F) << shift
-										if b_ < 0x80 {
-											break
-										}
-									}
-									if pos+int(v32_) > l {
-										return 0, io.ErrUnexpectedEOF
-									}
-									bs := data[pos : pos+int(v32_)]
-									s_ = *(*string)(unsafe.Pointer(&bs))
-									pos += int(v32_)
-								default:
-									return 0, fmt.Errorf("unknown string type %d at %d", b_, pos)
-								}
+								_ = s_
+
 							} else if bindSkipFieldType == typeMap.T_INT {
-								v32_ = uint32(0)
-								for shift = uint(0); ; shift += 7 {
-									if shift >= 32 {
-										return 0, def.ErrIntOverflow
-									}
-									if pos >= l {
-										return 0, io.ErrUnexpectedEOF
-									}
-									b_ = data[pos]
-									pos++
-									v32_ |= uint32(b_&0x7F) << shift
-									if b_ < 0x80 {
-										break
-									}
+
+								v32_, err := util.ParseVarInt(data, &pos)
+								if err != nil {
+									return 0, err
 								}
+								_ = v32_
+
 							} else if bindSkipFieldType == typeMap.T_FLOAT {
-								v32_ = uint32(0)
-								for shift = uint(0); ; shift += 7 {
-									if shift >= 32 {
-										return 0, def.ErrIntOverflow
-									}
-									if pos >= l {
-										return 0, io.ErrUnexpectedEOF
-									}
-									b_ = data[pos]
-									pos++
-									v32_ |= uint32(b_&0x7F) << shift
-									if b_ < 0x80 {
-										break
-									}
+
+								v32_, err := util.ParseVarInt(data, &pos)
+								if err != nil {
+									return 0, err
 								}
+								_ = v32_
+
 							} else if bindSkipFieldType == typeMap.T_LONG {
-								v64_ = 0
-								for shift = uint(0); shift <= 56; shift += 7 {
-									if pos >= l {
-										return 0, io.ErrUnexpectedEOF
-									}
-									b_ = data[pos]
-									pos++
-									if shift == 56 {
-										v64_ |= uint64(b_&0xFF) << shift
-										break
-									} else {
-										v64_ |= uint64(b_&0x7F) << shift
-										if b_ < 0x80 {
-											break
-										}
-									}
+
+								v64_, err := util.ParseVarLong(data, &pos)
+								if err != nil {
+									return 0, err
 								}
+								_ = v64_
+
 							} else if bindSkipFieldType == typeMap.T_BOOLEAN {
-								if pos >= l {
-									return 0, io.ErrUnexpectedEOF
+
+								b_, err := util.ParseByte(data, &pos)
+								if err != nil {
+									return 0, err
 								}
-								b_ = data[pos]
-								pos++
+								_ = b_
+
 							} else {
 								return 0, fmt.Errorf("nested objects not implemented. ")
 							}

--- a/parser/types/frametype.go
+++ b/parser/types/frametype.go
@@ -4,9 +4,9 @@ package types
 
 import (
 	"fmt"
+
 	"github.com/grafana/jfr-parser/parser/types/def"
-	"io"
-	"unsafe"
+	"github.com/grafana/jfr-parser/util"
 )
 
 type BindFrameType struct {
@@ -48,191 +48,95 @@ type FrameType struct {
 }
 
 func (this *FrameTypeList) Parse(data []byte, bind *BindFrameType, typeMap *def.TypeMap) (pos int, err error) {
-	var (
-		v64_  uint64
-		v32_  uint32
-		s_    string
-		b_    byte
-		shift = uint(0)
-		l     = len(data)
-	)
-	_ = v64_
-	_ = v32_
-	_ = s_
-	v32_ = uint32(0)
-	for shift = uint(0); ; shift += 7 {
-		if shift >= 32 {
-			return 0, def.ErrIntOverflow
-		}
-		if pos >= l {
-			return 0, io.ErrUnexpectedEOF
-		}
-		b_ = data[pos]
-		pos++
-		v32_ |= uint32(b_&0x7F) << shift
-		if b_ < 0x80 {
-			break
-		}
+
+	v32_, err := util.ParseVarInt(data, &pos)
+	if err != nil {
+		return 0, err
 	}
+	_ = v32_
+
 	n := int(v32_)
 	this.IDMap = make(map[FrameTypeRef]uint32, n)
 	this.FrameType = make([]FrameType, n)
 	for i := 0; i < n; i++ {
-		v32_ = uint32(0)
-		for shift = uint(0); ; shift += 7 {
-			if shift >= 32 {
-				return 0, def.ErrIntOverflow
-			}
-			if pos >= l {
-				return 0, io.ErrUnexpectedEOF
-			}
-			b_ = data[pos]
-			pos++
-			v32_ |= uint32(b_&0x7F) << shift
-			if b_ < 0x80 {
-				break
-			}
+
+		v32_, err := util.ParseVarInt(data, &pos)
+		if err != nil {
+			return 0, err
 		}
+		_ = v32_
+
 		id := FrameTypeRef(v32_)
 		for bindFieldIndex := 0; bindFieldIndex < len(bind.Fields); bindFieldIndex++ {
 			bindArraySize := 1
 			if bind.Fields[bindFieldIndex].Field.Array {
-				v32_ = uint32(0)
-				for shift = uint(0); ; shift += 7 {
-					if shift >= 32 {
-						return 0, def.ErrIntOverflow
-					}
-					if pos >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b_ = data[pos]
-					pos++
-					v32_ |= uint32(b_&0x7F) << shift
-					if b_ < 0x80 {
-						break
-					}
+
+				v32_, err := util.ParseVarInt(data, &pos)
+				if err != nil {
+					return 0, err
 				}
+				_ = v32_
+
 				bindArraySize = int(v32_)
 			}
 			for bindArrayIndex := 0; bindArrayIndex < bindArraySize; bindArrayIndex++ {
 				if bind.Fields[bindFieldIndex].Field.ConstantPool {
-					v32_ = uint32(0)
-					for shift = uint(0); ; shift += 7 {
-						if shift >= 32 {
-							return 0, def.ErrIntOverflow
-						}
-						if pos >= l {
-							return 0, io.ErrUnexpectedEOF
-						}
-						b_ = data[pos]
-						pos++
-						v32_ |= uint32(b_&0x7F) << shift
-						if b_ < 0x80 {
-							break
-						}
+
+					v32_, err := util.ParseVarInt(data, &pos)
+					if err != nil {
+						return 0, err
 					}
+					_ = v32_
+
 				} else {
 					bindFieldTypeID := bind.Fields[bindFieldIndex].Field.Type
 					switch bindFieldTypeID {
 					case typeMap.T_STRING:
-						s_ = ""
-						if pos >= l {
-							return 0, io.ErrUnexpectedEOF
+
+						s_, err := util.ParseString(data, &pos)
+						if err != nil {
+							return 0, err
 						}
-						b_ = data[pos]
-						pos++
-						switch b_ {
-						case 0:
-							break
-						case 1:
-							break
-						case 3:
-							v32_ = uint32(0)
-							for shift = uint(0); ; shift += 7 {
-								if shift >= 32 {
-									return 0, def.ErrIntOverflow
-								}
-								if pos >= l {
-									return 0, io.ErrUnexpectedEOF
-								}
-								b_ = data[pos]
-								pos++
-								v32_ |= uint32(b_&0x7F) << shift
-								if b_ < 0x80 {
-									break
-								}
-							}
-							if pos+int(v32_) > l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							bs := data[pos : pos+int(v32_)]
-							s_ = *(*string)(unsafe.Pointer(&bs))
-							pos += int(v32_)
-						default:
-							return 0, fmt.Errorf("unknown string type %d at %d", b_, pos)
-						}
+						_ = s_
+
 						if bind.Fields[bindFieldIndex].string != nil {
 							*bind.Fields[bindFieldIndex].string = s_
 						}
 					case typeMap.T_INT:
-						v32_ = uint32(0)
-						for shift = uint(0); ; shift += 7 {
-							if shift >= 32 {
-								return 0, def.ErrIntOverflow
-							}
-							if pos >= l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							b_ = data[pos]
-							pos++
-							v32_ |= uint32(b_&0x7F) << shift
-							if b_ < 0x80 {
-								break
-							}
+
+						v32_, err := util.ParseVarInt(data, &pos)
+						if err != nil {
+							return 0, err
 						}
+						_ = v32_
+
 						// skipping
 					case typeMap.T_LONG:
-						v64_ = 0
-						for shift = uint(0); shift <= 56; shift += 7 {
-							if pos >= l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							b_ = data[pos]
-							pos++
-							if shift == 56 {
-								v64_ |= uint64(b_&0xFF) << shift
-								break
-							} else {
-								v64_ |= uint64(b_&0x7F) << shift
-								if b_ < 0x80 {
-									break
-								}
-							}
+
+						v64_, err := util.ParseVarLong(data, &pos)
+						if err != nil {
+							return 0, err
 						}
+						_ = v64_
+
 						// skipping
 					case typeMap.T_BOOLEAN:
-						if pos >= l {
-							return 0, io.ErrUnexpectedEOF
+
+						b_, err := util.ParseByte(data, &pos)
+						if err != nil {
+							return 0, err
 						}
-						b_ = data[pos]
-						pos++
+						_ = b_
+
 						// skipping
 					case typeMap.T_FLOAT:
-						v32_ = uint32(0)
-						for shift = uint(0); ; shift += 7 {
-							if shift >= 32 {
-								return 0, def.ErrIntOverflow
-							}
-							if pos >= l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							b_ = data[pos]
-							pos++
-							v32_ |= uint32(b_&0x7F) << shift
-							if b_ < 0x80 {
-								break
-							}
+
+						v32_, err := util.ParseVarInt(data, &pos)
+						if err != nil {
+							return 0, err
 						}
+						_ = v32_
+
 						// skipping
 					default:
 						bindFieldType := typeMap.IDMap[bind.Fields[bindFieldIndex].Field.Type]
@@ -241,135 +145,66 @@ func (this *FrameTypeList) Parse(data []byte, bind *BindFrameType, typeMap *def.
 						}
 						bindSkipObjects := 1
 						if bind.Fields[bindFieldIndex].Field.Array {
-							v32_ = uint32(0)
-							for shift = uint(0); ; shift += 7 {
-								if shift >= 32 {
-									return 0, def.ErrIntOverflow
-								}
-								if pos >= l {
-									return 0, io.ErrUnexpectedEOF
-								}
-								b_ = data[pos]
-								pos++
-								v32_ |= uint32(b_&0x7F) << shift
-								if b_ < 0x80 {
-									break
-								}
+
+							v32_, err := util.ParseVarInt(data, &pos)
+							if err != nil {
+								return 0, err
 							}
+							_ = v32_
+
 							bindSkipObjects = int(v32_)
 						}
 						for bindSkipObjectIndex := 0; bindSkipObjectIndex < bindSkipObjects; bindSkipObjectIndex++ {
 							for bindskipFieldIndex := 0; bindskipFieldIndex < len(bindFieldType.Fields); bindskipFieldIndex++ {
 								bindSkipFieldType := bindFieldType.Fields[bindskipFieldIndex].Type
 								if bindFieldType.Fields[bindskipFieldIndex].ConstantPool {
-									v32_ = uint32(0)
-									for shift = uint(0); ; shift += 7 {
-										if shift >= 32 {
-											return 0, def.ErrIntOverflow
-										}
-										if pos >= l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										b_ = data[pos]
-										pos++
-										v32_ |= uint32(b_&0x7F) << shift
-										if b_ < 0x80 {
-											break
-										}
+
+									v32_, err := util.ParseVarInt(data, &pos)
+									if err != nil {
+										return 0, err
 									}
+									_ = v32_
+
 								} else if bindSkipFieldType == typeMap.T_STRING {
-									s_ = ""
-									if pos >= l {
-										return 0, io.ErrUnexpectedEOF
+
+									s_, err := util.ParseString(data, &pos)
+									if err != nil {
+										return 0, err
 									}
-									b_ = data[pos]
-									pos++
-									switch b_ {
-									case 0:
-										break
-									case 1:
-										break
-									case 3:
-										v32_ = uint32(0)
-										for shift = uint(0); ; shift += 7 {
-											if shift >= 32 {
-												return 0, def.ErrIntOverflow
-											}
-											if pos >= l {
-												return 0, io.ErrUnexpectedEOF
-											}
-											b_ = data[pos]
-											pos++
-											v32_ |= uint32(b_&0x7F) << shift
-											if b_ < 0x80 {
-												break
-											}
-										}
-										if pos+int(v32_) > l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										bs := data[pos : pos+int(v32_)]
-										s_ = *(*string)(unsafe.Pointer(&bs))
-										pos += int(v32_)
-									default:
-										return 0, fmt.Errorf("unknown string type %d at %d", b_, pos)
-									}
+									_ = s_
+
 								} else if bindSkipFieldType == typeMap.T_INT {
-									v32_ = uint32(0)
-									for shift = uint(0); ; shift += 7 {
-										if shift >= 32 {
-											return 0, def.ErrIntOverflow
-										}
-										if pos >= l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										b_ = data[pos]
-										pos++
-										v32_ |= uint32(b_&0x7F) << shift
-										if b_ < 0x80 {
-											break
-										}
+
+									v32_, err := util.ParseVarInt(data, &pos)
+									if err != nil {
+										return 0, err
 									}
+									_ = v32_
+
 								} else if bindSkipFieldType == typeMap.T_FLOAT {
-									v32_ = uint32(0)
-									for shift = uint(0); ; shift += 7 {
-										if shift >= 32 {
-											return 0, def.ErrIntOverflow
-										}
-										if pos >= l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										b_ = data[pos]
-										pos++
-										v32_ |= uint32(b_&0x7F) << shift
-										if b_ < 0x80 {
-											break
-										}
+
+									v32_, err := util.ParseVarInt(data, &pos)
+									if err != nil {
+										return 0, err
 									}
+									_ = v32_
+
 								} else if bindSkipFieldType == typeMap.T_LONG {
-									v64_ = 0
-									for shift = uint(0); shift <= 56; shift += 7 {
-										if pos >= l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										b_ = data[pos]
-										pos++
-										if shift == 56 {
-											v64_ |= uint64(b_&0xFF) << shift
-											break
-										} else {
-											v64_ |= uint64(b_&0x7F) << shift
-											if b_ < 0x80 {
-												break
-											}
-										}
+
+									v64_, err := util.ParseVarLong(data, &pos)
+									if err != nil {
+										return 0, err
 									}
+									_ = v64_
+
 								} else if bindSkipFieldType == typeMap.T_BOOLEAN {
-									if pos >= l {
-										return 0, io.ErrUnexpectedEOF
+
+									b_, err := util.ParseByte(data, &pos)
+									if err != nil {
+										return 0, err
 									}
-									b_ = data[pos]
-									pos++
+									_ = b_
+
 								} else {
 									return 0, fmt.Errorf("nested objects not implemented. ")
 								}

--- a/parser/types/live_object.go
+++ b/parser/types/live_object.go
@@ -4,9 +4,9 @@ package types
 
 import (
 	"fmt"
+
 	"github.com/grafana/jfr-parser/parser/types/def"
-	"io"
-	"unsafe"
+	"github.com/grafana/jfr-parser/util"
 )
 
 type BindLiveObject struct {
@@ -80,54 +80,27 @@ type LiveObject struct {
 }
 
 func (this *LiveObject) Parse(data []byte, bind *BindLiveObject, typeMap *def.TypeMap) (pos int, err error) {
-	var (
-		v64_  uint64
-		v32_  uint32
-		s_    string
-		b_    byte
-		shift = uint(0)
-		l     = len(data)
-	)
-	_ = v64_
-	_ = v32_
-	_ = s_
 	for bindFieldIndex := 0; bindFieldIndex < len(bind.Fields); bindFieldIndex++ {
 		bindArraySize := 1
 		if bind.Fields[bindFieldIndex].Field.Array {
-			v32_ = uint32(0)
-			for shift = uint(0); ; shift += 7 {
-				if shift >= 32 {
-					return 0, def.ErrIntOverflow
-				}
-				if pos >= l {
-					return 0, io.ErrUnexpectedEOF
-				}
-				b_ = data[pos]
-				pos++
-				v32_ |= uint32(b_&0x7F) << shift
-				if b_ < 0x80 {
-					break
-				}
+
+			v32_, err := util.ParseVarInt(data, &pos)
+			if err != nil {
+				return 0, err
 			}
+			_ = v32_
+
 			bindArraySize = int(v32_)
 		}
 		for bindArrayIndex := 0; bindArrayIndex < bindArraySize; bindArrayIndex++ {
 			if bind.Fields[bindFieldIndex].Field.ConstantPool {
-				v32_ = uint32(0)
-				for shift = uint(0); ; shift += 7 {
-					if shift >= 32 {
-						return 0, def.ErrIntOverflow
-					}
-					if pos >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b_ = data[pos]
-					pos++
-					v32_ |= uint32(b_&0x7F) << shift
-					if b_ < 0x80 {
-						break
-					}
+
+				v32_, err := util.ParseVarInt(data, &pos)
+				if err != nil {
+					return 0, err
 				}
+				_ = v32_
+
 				switch bind.Fields[bindFieldIndex].Field.Type {
 				case typeMap.T_THREAD:
 					if bind.Fields[bindFieldIndex].ThreadRef != nil {
@@ -146,104 +119,51 @@ func (this *LiveObject) Parse(data []byte, bind *BindLiveObject, typeMap *def.Ty
 				bindFieldTypeID := bind.Fields[bindFieldIndex].Field.Type
 				switch bindFieldTypeID {
 				case typeMap.T_STRING:
-					s_ = ""
-					if pos >= l {
-						return 0, io.ErrUnexpectedEOF
+
+					s_, err := util.ParseString(data, &pos)
+					if err != nil {
+						return 0, err
 					}
-					b_ = data[pos]
-					pos++
-					switch b_ {
-					case 0:
-						break
-					case 1:
-						break
-					case 3:
-						v32_ = uint32(0)
-						for shift = uint(0); ; shift += 7 {
-							if shift >= 32 {
-								return 0, def.ErrIntOverflow
-							}
-							if pos >= l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							b_ = data[pos]
-							pos++
-							v32_ |= uint32(b_&0x7F) << shift
-							if b_ < 0x80 {
-								break
-							}
-						}
-						if pos+int(v32_) > l {
-							return 0, io.ErrUnexpectedEOF
-						}
-						bs := data[pos : pos+int(v32_)]
-						s_ = *(*string)(unsafe.Pointer(&bs))
-						pos += int(v32_)
-					default:
-						return 0, fmt.Errorf("unknown string type %d at %d", b_, pos)
-					}
+					_ = s_
+
 					// skipping
 				case typeMap.T_INT:
-					v32_ = uint32(0)
-					for shift = uint(0); ; shift += 7 {
-						if shift >= 32 {
-							return 0, def.ErrIntOverflow
-						}
-						if pos >= l {
-							return 0, io.ErrUnexpectedEOF
-						}
-						b_ = data[pos]
-						pos++
-						v32_ |= uint32(b_&0x7F) << shift
-						if b_ < 0x80 {
-							break
-						}
+
+					v32_, err := util.ParseVarInt(data, &pos)
+					if err != nil {
+						return 0, err
 					}
+					_ = v32_
+
 					// skipping
 				case typeMap.T_LONG:
-					v64_ = 0
-					for shift = uint(0); shift <= 56; shift += 7 {
-						if pos >= l {
-							return 0, io.ErrUnexpectedEOF
-						}
-						b_ = data[pos]
-						pos++
-						if shift == 56 {
-							v64_ |= uint64(b_&0xFF) << shift
-							break
-						} else {
-							v64_ |= uint64(b_&0x7F) << shift
-							if b_ < 0x80 {
-								break
-							}
-						}
+
+					v64_, err := util.ParseVarLong(data, &pos)
+					if err != nil {
+						return 0, err
 					}
+					_ = v64_
+
 					if bind.Fields[bindFieldIndex].uint64 != nil {
 						*bind.Fields[bindFieldIndex].uint64 = v64_
 					}
 				case typeMap.T_BOOLEAN:
-					if pos >= l {
-						return 0, io.ErrUnexpectedEOF
+
+					b_, err := util.ParseByte(data, &pos)
+					if err != nil {
+						return 0, err
 					}
-					b_ = data[pos]
-					pos++
+					_ = b_
+
 					// skipping
 				case typeMap.T_FLOAT:
-					v32_ = uint32(0)
-					for shift = uint(0); ; shift += 7 {
-						if shift >= 32 {
-							return 0, def.ErrIntOverflow
-						}
-						if pos >= l {
-							return 0, io.ErrUnexpectedEOF
-						}
-						b_ = data[pos]
-						pos++
-						v32_ |= uint32(b_&0x7F) << shift
-						if b_ < 0x80 {
-							break
-						}
+
+					v32_, err := util.ParseVarInt(data, &pos)
+					if err != nil {
+						return 0, err
 					}
+					_ = v32_
+
 					// skipping
 				default:
 					bindFieldType := typeMap.IDMap[bind.Fields[bindFieldIndex].Field.Type]
@@ -252,135 +172,66 @@ func (this *LiveObject) Parse(data []byte, bind *BindLiveObject, typeMap *def.Ty
 					}
 					bindSkipObjects := 1
 					if bind.Fields[bindFieldIndex].Field.Array {
-						v32_ = uint32(0)
-						for shift = uint(0); ; shift += 7 {
-							if shift >= 32 {
-								return 0, def.ErrIntOverflow
-							}
-							if pos >= l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							b_ = data[pos]
-							pos++
-							v32_ |= uint32(b_&0x7F) << shift
-							if b_ < 0x80 {
-								break
-							}
+
+						v32_, err := util.ParseVarInt(data, &pos)
+						if err != nil {
+							return 0, err
 						}
+						_ = v32_
+
 						bindSkipObjects = int(v32_)
 					}
 					for bindSkipObjectIndex := 0; bindSkipObjectIndex < bindSkipObjects; bindSkipObjectIndex++ {
 						for bindskipFieldIndex := 0; bindskipFieldIndex < len(bindFieldType.Fields); bindskipFieldIndex++ {
 							bindSkipFieldType := bindFieldType.Fields[bindskipFieldIndex].Type
 							if bindFieldType.Fields[bindskipFieldIndex].ConstantPool {
-								v32_ = uint32(0)
-								for shift = uint(0); ; shift += 7 {
-									if shift >= 32 {
-										return 0, def.ErrIntOverflow
-									}
-									if pos >= l {
-										return 0, io.ErrUnexpectedEOF
-									}
-									b_ = data[pos]
-									pos++
-									v32_ |= uint32(b_&0x7F) << shift
-									if b_ < 0x80 {
-										break
-									}
+
+								v32_, err := util.ParseVarInt(data, &pos)
+								if err != nil {
+									return 0, err
 								}
+								_ = v32_
+
 							} else if bindSkipFieldType == typeMap.T_STRING {
-								s_ = ""
-								if pos >= l {
-									return 0, io.ErrUnexpectedEOF
+
+								s_, err := util.ParseString(data, &pos)
+								if err != nil {
+									return 0, err
 								}
-								b_ = data[pos]
-								pos++
-								switch b_ {
-								case 0:
-									break
-								case 1:
-									break
-								case 3:
-									v32_ = uint32(0)
-									for shift = uint(0); ; shift += 7 {
-										if shift >= 32 {
-											return 0, def.ErrIntOverflow
-										}
-										if pos >= l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										b_ = data[pos]
-										pos++
-										v32_ |= uint32(b_&0x7F) << shift
-										if b_ < 0x80 {
-											break
-										}
-									}
-									if pos+int(v32_) > l {
-										return 0, io.ErrUnexpectedEOF
-									}
-									bs := data[pos : pos+int(v32_)]
-									s_ = *(*string)(unsafe.Pointer(&bs))
-									pos += int(v32_)
-								default:
-									return 0, fmt.Errorf("unknown string type %d at %d", b_, pos)
-								}
+								_ = s_
+
 							} else if bindSkipFieldType == typeMap.T_INT {
-								v32_ = uint32(0)
-								for shift = uint(0); ; shift += 7 {
-									if shift >= 32 {
-										return 0, def.ErrIntOverflow
-									}
-									if pos >= l {
-										return 0, io.ErrUnexpectedEOF
-									}
-									b_ = data[pos]
-									pos++
-									v32_ |= uint32(b_&0x7F) << shift
-									if b_ < 0x80 {
-										break
-									}
+
+								v32_, err := util.ParseVarInt(data, &pos)
+								if err != nil {
+									return 0, err
 								}
+								_ = v32_
+
 							} else if bindSkipFieldType == typeMap.T_FLOAT {
-								v32_ = uint32(0)
-								for shift = uint(0); ; shift += 7 {
-									if shift >= 32 {
-										return 0, def.ErrIntOverflow
-									}
-									if pos >= l {
-										return 0, io.ErrUnexpectedEOF
-									}
-									b_ = data[pos]
-									pos++
-									v32_ |= uint32(b_&0x7F) << shift
-									if b_ < 0x80 {
-										break
-									}
+
+								v32_, err := util.ParseVarInt(data, &pos)
+								if err != nil {
+									return 0, err
 								}
+								_ = v32_
+
 							} else if bindSkipFieldType == typeMap.T_LONG {
-								v64_ = 0
-								for shift = uint(0); shift <= 56; shift += 7 {
-									if pos >= l {
-										return 0, io.ErrUnexpectedEOF
-									}
-									b_ = data[pos]
-									pos++
-									if shift == 56 {
-										v64_ |= uint64(b_&0xFF) << shift
-										break
-									} else {
-										v64_ |= uint64(b_&0x7F) << shift
-										if b_ < 0x80 {
-											break
-										}
-									}
+
+								v64_, err := util.ParseVarLong(data, &pos)
+								if err != nil {
+									return 0, err
 								}
+								_ = v64_
+
 							} else if bindSkipFieldType == typeMap.T_BOOLEAN {
-								if pos >= l {
-									return 0, io.ErrUnexpectedEOF
+
+								b_, err := util.ParseByte(data, &pos)
+								if err != nil {
+									return 0, err
 								}
-								b_ = data[pos]
-								pos++
+								_ = b_
+
 							} else {
 								return 0, fmt.Errorf("nested objects not implemented. ")
 							}

--- a/parser/types/loglevel.go
+++ b/parser/types/loglevel.go
@@ -4,9 +4,9 @@ package types
 
 import (
 	"fmt"
+
 	"github.com/grafana/jfr-parser/parser/types/def"
-	"io"
-	"unsafe"
+	"github.com/grafana/jfr-parser/util"
 )
 
 type BindLogLevel struct {
@@ -48,191 +48,95 @@ type LogLevel struct {
 }
 
 func (this *LogLevelList) Parse(data []byte, bind *BindLogLevel, typeMap *def.TypeMap) (pos int, err error) {
-	var (
-		v64_  uint64
-		v32_  uint32
-		s_    string
-		b_    byte
-		shift = uint(0)
-		l     = len(data)
-	)
-	_ = v64_
-	_ = v32_
-	_ = s_
-	v32_ = uint32(0)
-	for shift = uint(0); ; shift += 7 {
-		if shift >= 32 {
-			return 0, def.ErrIntOverflow
-		}
-		if pos >= l {
-			return 0, io.ErrUnexpectedEOF
-		}
-		b_ = data[pos]
-		pos++
-		v32_ |= uint32(b_&0x7F) << shift
-		if b_ < 0x80 {
-			break
-		}
+
+	v32_, err := util.ParseVarInt(data, &pos)
+	if err != nil {
+		return 0, err
 	}
+	_ = v32_
+
 	n := int(v32_)
 	this.IDMap = make(map[LogLevelRef]uint32, n)
 	this.LogLevel = make([]LogLevel, n)
 	for i := 0; i < n; i++ {
-		v32_ = uint32(0)
-		for shift = uint(0); ; shift += 7 {
-			if shift >= 32 {
-				return 0, def.ErrIntOverflow
-			}
-			if pos >= l {
-				return 0, io.ErrUnexpectedEOF
-			}
-			b_ = data[pos]
-			pos++
-			v32_ |= uint32(b_&0x7F) << shift
-			if b_ < 0x80 {
-				break
-			}
+
+		v32_, err := util.ParseVarInt(data, &pos)
+		if err != nil {
+			return 0, err
 		}
+		_ = v32_
+
 		id := LogLevelRef(v32_)
 		for bindFieldIndex := 0; bindFieldIndex < len(bind.Fields); bindFieldIndex++ {
 			bindArraySize := 1
 			if bind.Fields[bindFieldIndex].Field.Array {
-				v32_ = uint32(0)
-				for shift = uint(0); ; shift += 7 {
-					if shift >= 32 {
-						return 0, def.ErrIntOverflow
-					}
-					if pos >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b_ = data[pos]
-					pos++
-					v32_ |= uint32(b_&0x7F) << shift
-					if b_ < 0x80 {
-						break
-					}
+
+				v32_, err := util.ParseVarInt(data, &pos)
+				if err != nil {
+					return 0, err
 				}
+				_ = v32_
+
 				bindArraySize = int(v32_)
 			}
 			for bindArrayIndex := 0; bindArrayIndex < bindArraySize; bindArrayIndex++ {
 				if bind.Fields[bindFieldIndex].Field.ConstantPool {
-					v32_ = uint32(0)
-					for shift = uint(0); ; shift += 7 {
-						if shift >= 32 {
-							return 0, def.ErrIntOverflow
-						}
-						if pos >= l {
-							return 0, io.ErrUnexpectedEOF
-						}
-						b_ = data[pos]
-						pos++
-						v32_ |= uint32(b_&0x7F) << shift
-						if b_ < 0x80 {
-							break
-						}
+
+					v32_, err := util.ParseVarInt(data, &pos)
+					if err != nil {
+						return 0, err
 					}
+					_ = v32_
+
 				} else {
 					bindFieldTypeID := bind.Fields[bindFieldIndex].Field.Type
 					switch bindFieldTypeID {
 					case typeMap.T_STRING:
-						s_ = ""
-						if pos >= l {
-							return 0, io.ErrUnexpectedEOF
+
+						s_, err := util.ParseString(data, &pos)
+						if err != nil {
+							return 0, err
 						}
-						b_ = data[pos]
-						pos++
-						switch b_ {
-						case 0:
-							break
-						case 1:
-							break
-						case 3:
-							v32_ = uint32(0)
-							for shift = uint(0); ; shift += 7 {
-								if shift >= 32 {
-									return 0, def.ErrIntOverflow
-								}
-								if pos >= l {
-									return 0, io.ErrUnexpectedEOF
-								}
-								b_ = data[pos]
-								pos++
-								v32_ |= uint32(b_&0x7F) << shift
-								if b_ < 0x80 {
-									break
-								}
-							}
-							if pos+int(v32_) > l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							bs := data[pos : pos+int(v32_)]
-							s_ = *(*string)(unsafe.Pointer(&bs))
-							pos += int(v32_)
-						default:
-							return 0, fmt.Errorf("unknown string type %d at %d", b_, pos)
-						}
+						_ = s_
+
 						if bind.Fields[bindFieldIndex].string != nil {
 							*bind.Fields[bindFieldIndex].string = s_
 						}
 					case typeMap.T_INT:
-						v32_ = uint32(0)
-						for shift = uint(0); ; shift += 7 {
-							if shift >= 32 {
-								return 0, def.ErrIntOverflow
-							}
-							if pos >= l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							b_ = data[pos]
-							pos++
-							v32_ |= uint32(b_&0x7F) << shift
-							if b_ < 0x80 {
-								break
-							}
+
+						v32_, err := util.ParseVarInt(data, &pos)
+						if err != nil {
+							return 0, err
 						}
+						_ = v32_
+
 						// skipping
 					case typeMap.T_LONG:
-						v64_ = 0
-						for shift = uint(0); shift <= 56; shift += 7 {
-							if pos >= l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							b_ = data[pos]
-							pos++
-							if shift == 56 {
-								v64_ |= uint64(b_&0xFF) << shift
-								break
-							} else {
-								v64_ |= uint64(b_&0x7F) << shift
-								if b_ < 0x80 {
-									break
-								}
-							}
+
+						v64_, err := util.ParseVarLong(data, &pos)
+						if err != nil {
+							return 0, err
 						}
+						_ = v64_
+
 						// skipping
 					case typeMap.T_BOOLEAN:
-						if pos >= l {
-							return 0, io.ErrUnexpectedEOF
+
+						b_, err := util.ParseByte(data, &pos)
+						if err != nil {
+							return 0, err
 						}
-						b_ = data[pos]
-						pos++
+						_ = b_
+
 						// skipping
 					case typeMap.T_FLOAT:
-						v32_ = uint32(0)
-						for shift = uint(0); ; shift += 7 {
-							if shift >= 32 {
-								return 0, def.ErrIntOverflow
-							}
-							if pos >= l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							b_ = data[pos]
-							pos++
-							v32_ |= uint32(b_&0x7F) << shift
-							if b_ < 0x80 {
-								break
-							}
+
+						v32_, err := util.ParseVarInt(data, &pos)
+						if err != nil {
+							return 0, err
 						}
+						_ = v32_
+
 						// skipping
 					default:
 						bindFieldType := typeMap.IDMap[bind.Fields[bindFieldIndex].Field.Type]
@@ -241,135 +145,66 @@ func (this *LogLevelList) Parse(data []byte, bind *BindLogLevel, typeMap *def.Ty
 						}
 						bindSkipObjects := 1
 						if bind.Fields[bindFieldIndex].Field.Array {
-							v32_ = uint32(0)
-							for shift = uint(0); ; shift += 7 {
-								if shift >= 32 {
-									return 0, def.ErrIntOverflow
-								}
-								if pos >= l {
-									return 0, io.ErrUnexpectedEOF
-								}
-								b_ = data[pos]
-								pos++
-								v32_ |= uint32(b_&0x7F) << shift
-								if b_ < 0x80 {
-									break
-								}
+
+							v32_, err := util.ParseVarInt(data, &pos)
+							if err != nil {
+								return 0, err
 							}
+							_ = v32_
+
 							bindSkipObjects = int(v32_)
 						}
 						for bindSkipObjectIndex := 0; bindSkipObjectIndex < bindSkipObjects; bindSkipObjectIndex++ {
 							for bindskipFieldIndex := 0; bindskipFieldIndex < len(bindFieldType.Fields); bindskipFieldIndex++ {
 								bindSkipFieldType := bindFieldType.Fields[bindskipFieldIndex].Type
 								if bindFieldType.Fields[bindskipFieldIndex].ConstantPool {
-									v32_ = uint32(0)
-									for shift = uint(0); ; shift += 7 {
-										if shift >= 32 {
-											return 0, def.ErrIntOverflow
-										}
-										if pos >= l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										b_ = data[pos]
-										pos++
-										v32_ |= uint32(b_&0x7F) << shift
-										if b_ < 0x80 {
-											break
-										}
+
+									v32_, err := util.ParseVarInt(data, &pos)
+									if err != nil {
+										return 0, err
 									}
+									_ = v32_
+
 								} else if bindSkipFieldType == typeMap.T_STRING {
-									s_ = ""
-									if pos >= l {
-										return 0, io.ErrUnexpectedEOF
+
+									s_, err := util.ParseString(data, &pos)
+									if err != nil {
+										return 0, err
 									}
-									b_ = data[pos]
-									pos++
-									switch b_ {
-									case 0:
-										break
-									case 1:
-										break
-									case 3:
-										v32_ = uint32(0)
-										for shift = uint(0); ; shift += 7 {
-											if shift >= 32 {
-												return 0, def.ErrIntOverflow
-											}
-											if pos >= l {
-												return 0, io.ErrUnexpectedEOF
-											}
-											b_ = data[pos]
-											pos++
-											v32_ |= uint32(b_&0x7F) << shift
-											if b_ < 0x80 {
-												break
-											}
-										}
-										if pos+int(v32_) > l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										bs := data[pos : pos+int(v32_)]
-										s_ = *(*string)(unsafe.Pointer(&bs))
-										pos += int(v32_)
-									default:
-										return 0, fmt.Errorf("unknown string type %d at %d", b_, pos)
-									}
+									_ = s_
+
 								} else if bindSkipFieldType == typeMap.T_INT {
-									v32_ = uint32(0)
-									for shift = uint(0); ; shift += 7 {
-										if shift >= 32 {
-											return 0, def.ErrIntOverflow
-										}
-										if pos >= l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										b_ = data[pos]
-										pos++
-										v32_ |= uint32(b_&0x7F) << shift
-										if b_ < 0x80 {
-											break
-										}
+
+									v32_, err := util.ParseVarInt(data, &pos)
+									if err != nil {
+										return 0, err
 									}
+									_ = v32_
+
 								} else if bindSkipFieldType == typeMap.T_FLOAT {
-									v32_ = uint32(0)
-									for shift = uint(0); ; shift += 7 {
-										if shift >= 32 {
-											return 0, def.ErrIntOverflow
-										}
-										if pos >= l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										b_ = data[pos]
-										pos++
-										v32_ |= uint32(b_&0x7F) << shift
-										if b_ < 0x80 {
-											break
-										}
+
+									v32_, err := util.ParseVarInt(data, &pos)
+									if err != nil {
+										return 0, err
 									}
+									_ = v32_
+
 								} else if bindSkipFieldType == typeMap.T_LONG {
-									v64_ = 0
-									for shift = uint(0); shift <= 56; shift += 7 {
-										if pos >= l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										b_ = data[pos]
-										pos++
-										if shift == 56 {
-											v64_ |= uint64(b_&0xFF) << shift
-											break
-										} else {
-											v64_ |= uint64(b_&0x7F) << shift
-											if b_ < 0x80 {
-												break
-											}
-										}
+
+									v64_, err := util.ParseVarLong(data, &pos)
+									if err != nil {
+										return 0, err
 									}
+									_ = v64_
+
 								} else if bindSkipFieldType == typeMap.T_BOOLEAN {
-									if pos >= l {
-										return 0, io.ErrUnexpectedEOF
+
+									b_, err := util.ParseByte(data, &pos)
+									if err != nil {
+										return 0, err
 									}
-									b_ = data[pos]
-									pos++
+									_ = b_
+
 								} else {
 									return 0, fmt.Errorf("nested objects not implemented. ")
 								}

--- a/parser/types/method.go
+++ b/parser/types/method.go
@@ -4,9 +4,9 @@ package types
 
 import (
 	"fmt"
+
 	"github.com/grafana/jfr-parser/parser/types/def"
-	"io"
-	"unsafe"
+	"github.com/grafana/jfr-parser/util"
 )
 
 type BindMethod struct {
@@ -67,89 +67,46 @@ type Method struct {
 }
 
 func (this *MethodList) Parse(data []byte, bind *BindMethod, typeMap *def.TypeMap) (pos int, err error) {
-	var (
-		v64_  uint64
-		v32_  uint32
-		s_    string
-		b_    byte
-		shift = uint(0)
-		l     = len(data)
-	)
-	_ = v64_
-	_ = v32_
-	_ = s_
-	v32_ = uint32(0)
-	for shift = uint(0); ; shift += 7 {
-		if shift >= 32 {
-			return 0, def.ErrIntOverflow
-		}
-		if pos >= l {
-			return 0, io.ErrUnexpectedEOF
-		}
-		b_ = data[pos]
-		pos++
-		v32_ |= uint32(b_&0x7F) << shift
-		if b_ < 0x80 {
-			break
-		}
+
+	v32_, err := util.ParseVarInt(data, &pos)
+	if err != nil {
+		return 0, err
 	}
+	_ = v32_
+
 	n := int(v32_)
 	this.IDMap = NewIDMap[MethodRef](n)
 	this.Method = make([]Method, n)
 	for i := 0; i < n; i++ {
-		v32_ = uint32(0)
-		for shift = uint(0); ; shift += 7 {
-			if shift >= 32 {
-				return 0, def.ErrIntOverflow
-			}
-			if pos >= l {
-				return 0, io.ErrUnexpectedEOF
-			}
-			b_ = data[pos]
-			pos++
-			v32_ |= uint32(b_&0x7F) << shift
-			if b_ < 0x80 {
-				break
-			}
+
+		v32_, err := util.ParseVarInt(data, &pos)
+		if err != nil {
+			return 0, err
 		}
+		_ = v32_
+
 		id := MethodRef(v32_)
 		for bindFieldIndex := 0; bindFieldIndex < len(bind.Fields); bindFieldIndex++ {
 			bindArraySize := 1
 			if bind.Fields[bindFieldIndex].Field.Array {
-				v32_ = uint32(0)
-				for shift = uint(0); ; shift += 7 {
-					if shift >= 32 {
-						return 0, def.ErrIntOverflow
-					}
-					if pos >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b_ = data[pos]
-					pos++
-					v32_ |= uint32(b_&0x7F) << shift
-					if b_ < 0x80 {
-						break
-					}
+
+				v32_, err := util.ParseVarInt(data, &pos)
+				if err != nil {
+					return 0, err
 				}
+				_ = v32_
+
 				bindArraySize = int(v32_)
 			}
 			for bindArrayIndex := 0; bindArrayIndex < bindArraySize; bindArrayIndex++ {
 				if bind.Fields[bindFieldIndex].Field.ConstantPool {
-					v32_ = uint32(0)
-					for shift = uint(0); ; shift += 7 {
-						if shift >= 32 {
-							return 0, def.ErrIntOverflow
-						}
-						if pos >= l {
-							return 0, io.ErrUnexpectedEOF
-						}
-						b_ = data[pos]
-						pos++
-						v32_ |= uint32(b_&0x7F) << shift
-						if b_ < 0x80 {
-							break
-						}
+
+					v32_, err := util.ParseVarInt(data, &pos)
+					if err != nil {
+						return 0, err
 					}
+					_ = v32_
+
 					switch bind.Fields[bindFieldIndex].Field.Type {
 					case typeMap.T_CLASS:
 						if bind.Fields[bindFieldIndex].ClassRef != nil {
@@ -164,106 +121,53 @@ func (this *MethodList) Parse(data []byte, bind *BindMethod, typeMap *def.TypeMa
 					bindFieldTypeID := bind.Fields[bindFieldIndex].Field.Type
 					switch bindFieldTypeID {
 					case typeMap.T_STRING:
-						s_ = ""
-						if pos >= l {
-							return 0, io.ErrUnexpectedEOF
+
+						s_, err := util.ParseString(data, &pos)
+						if err != nil {
+							return 0, err
 						}
-						b_ = data[pos]
-						pos++
-						switch b_ {
-						case 0:
-							break
-						case 1:
-							break
-						case 3:
-							v32_ = uint32(0)
-							for shift = uint(0); ; shift += 7 {
-								if shift >= 32 {
-									return 0, def.ErrIntOverflow
-								}
-								if pos >= l {
-									return 0, io.ErrUnexpectedEOF
-								}
-								b_ = data[pos]
-								pos++
-								v32_ |= uint32(b_&0x7F) << shift
-								if b_ < 0x80 {
-									break
-								}
-							}
-							if pos+int(v32_) > l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							bs := data[pos : pos+int(v32_)]
-							s_ = *(*string)(unsafe.Pointer(&bs))
-							pos += int(v32_)
-						default:
-							return 0, fmt.Errorf("unknown string type %d at %d", b_, pos)
-						}
+						_ = s_
+
 						// skipping
 					case typeMap.T_INT:
-						v32_ = uint32(0)
-						for shift = uint(0); ; shift += 7 {
-							if shift >= 32 {
-								return 0, def.ErrIntOverflow
-							}
-							if pos >= l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							b_ = data[pos]
-							pos++
-							v32_ |= uint32(b_&0x7F) << shift
-							if b_ < 0x80 {
-								break
-							}
+
+						v32_, err := util.ParseVarInt(data, &pos)
+						if err != nil {
+							return 0, err
 						}
+						_ = v32_
+
 						if bind.Fields[bindFieldIndex].uint32 != nil {
 							*bind.Fields[bindFieldIndex].uint32 = v32_
 						}
 					case typeMap.T_LONG:
-						v64_ = 0
-						for shift = uint(0); shift <= 56; shift += 7 {
-							if pos >= l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							b_ = data[pos]
-							pos++
-							if shift == 56 {
-								v64_ |= uint64(b_&0xFF) << shift
-								break
-							} else {
-								v64_ |= uint64(b_&0x7F) << shift
-								if b_ < 0x80 {
-									break
-								}
-							}
+
+						v64_, err := util.ParseVarLong(data, &pos)
+						if err != nil {
+							return 0, err
 						}
+						_ = v64_
+
 						// skipping
 					case typeMap.T_BOOLEAN:
-						if pos >= l {
-							return 0, io.ErrUnexpectedEOF
+
+						b_, err := util.ParseByte(data, &pos)
+						if err != nil {
+							return 0, err
 						}
-						b_ = data[pos]
-						pos++
+						_ = b_
+
 						if bind.Fields[bindFieldIndex].bool != nil {
 							*bind.Fields[bindFieldIndex].bool = b_ != 0
 						}
 					case typeMap.T_FLOAT:
-						v32_ = uint32(0)
-						for shift = uint(0); ; shift += 7 {
-							if shift >= 32 {
-								return 0, def.ErrIntOverflow
-							}
-							if pos >= l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							b_ = data[pos]
-							pos++
-							v32_ |= uint32(b_&0x7F) << shift
-							if b_ < 0x80 {
-								break
-							}
+
+						v32_, err := util.ParseVarInt(data, &pos)
+						if err != nil {
+							return 0, err
 						}
+						_ = v32_
+
 						// skipping
 					default:
 						bindFieldType := typeMap.IDMap[bind.Fields[bindFieldIndex].Field.Type]
@@ -272,135 +176,66 @@ func (this *MethodList) Parse(data []byte, bind *BindMethod, typeMap *def.TypeMa
 						}
 						bindSkipObjects := 1
 						if bind.Fields[bindFieldIndex].Field.Array {
-							v32_ = uint32(0)
-							for shift = uint(0); ; shift += 7 {
-								if shift >= 32 {
-									return 0, def.ErrIntOverflow
-								}
-								if pos >= l {
-									return 0, io.ErrUnexpectedEOF
-								}
-								b_ = data[pos]
-								pos++
-								v32_ |= uint32(b_&0x7F) << shift
-								if b_ < 0x80 {
-									break
-								}
+
+							v32_, err := util.ParseVarInt(data, &pos)
+							if err != nil {
+								return 0, err
 							}
+							_ = v32_
+
 							bindSkipObjects = int(v32_)
 						}
 						for bindSkipObjectIndex := 0; bindSkipObjectIndex < bindSkipObjects; bindSkipObjectIndex++ {
 							for bindskipFieldIndex := 0; bindskipFieldIndex < len(bindFieldType.Fields); bindskipFieldIndex++ {
 								bindSkipFieldType := bindFieldType.Fields[bindskipFieldIndex].Type
 								if bindFieldType.Fields[bindskipFieldIndex].ConstantPool {
-									v32_ = uint32(0)
-									for shift = uint(0); ; shift += 7 {
-										if shift >= 32 {
-											return 0, def.ErrIntOverflow
-										}
-										if pos >= l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										b_ = data[pos]
-										pos++
-										v32_ |= uint32(b_&0x7F) << shift
-										if b_ < 0x80 {
-											break
-										}
+
+									v32_, err := util.ParseVarInt(data, &pos)
+									if err != nil {
+										return 0, err
 									}
+									_ = v32_
+
 								} else if bindSkipFieldType == typeMap.T_STRING {
-									s_ = ""
-									if pos >= l {
-										return 0, io.ErrUnexpectedEOF
+
+									s_, err := util.ParseString(data, &pos)
+									if err != nil {
+										return 0, err
 									}
-									b_ = data[pos]
-									pos++
-									switch b_ {
-									case 0:
-										break
-									case 1:
-										break
-									case 3:
-										v32_ = uint32(0)
-										for shift = uint(0); ; shift += 7 {
-											if shift >= 32 {
-												return 0, def.ErrIntOverflow
-											}
-											if pos >= l {
-												return 0, io.ErrUnexpectedEOF
-											}
-											b_ = data[pos]
-											pos++
-											v32_ |= uint32(b_&0x7F) << shift
-											if b_ < 0x80 {
-												break
-											}
-										}
-										if pos+int(v32_) > l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										bs := data[pos : pos+int(v32_)]
-										s_ = *(*string)(unsafe.Pointer(&bs))
-										pos += int(v32_)
-									default:
-										return 0, fmt.Errorf("unknown string type %d at %d", b_, pos)
-									}
+									_ = s_
+
 								} else if bindSkipFieldType == typeMap.T_INT {
-									v32_ = uint32(0)
-									for shift = uint(0); ; shift += 7 {
-										if shift >= 32 {
-											return 0, def.ErrIntOverflow
-										}
-										if pos >= l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										b_ = data[pos]
-										pos++
-										v32_ |= uint32(b_&0x7F) << shift
-										if b_ < 0x80 {
-											break
-										}
+
+									v32_, err := util.ParseVarInt(data, &pos)
+									if err != nil {
+										return 0, err
 									}
+									_ = v32_
+
 								} else if bindSkipFieldType == typeMap.T_FLOAT {
-									v32_ = uint32(0)
-									for shift = uint(0); ; shift += 7 {
-										if shift >= 32 {
-											return 0, def.ErrIntOverflow
-										}
-										if pos >= l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										b_ = data[pos]
-										pos++
-										v32_ |= uint32(b_&0x7F) << shift
-										if b_ < 0x80 {
-											break
-										}
+
+									v32_, err := util.ParseVarInt(data, &pos)
+									if err != nil {
+										return 0, err
 									}
+									_ = v32_
+
 								} else if bindSkipFieldType == typeMap.T_LONG {
-									v64_ = 0
-									for shift = uint(0); shift <= 56; shift += 7 {
-										if pos >= l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										b_ = data[pos]
-										pos++
-										if shift == 56 {
-											v64_ |= uint64(b_&0xFF) << shift
-											break
-										} else {
-											v64_ |= uint64(b_&0x7F) << shift
-											if b_ < 0x80 {
-												break
-											}
-										}
+
+									v64_, err := util.ParseVarLong(data, &pos)
+									if err != nil {
+										return 0, err
 									}
+									_ = v64_
+
 								} else if bindSkipFieldType == typeMap.T_BOOLEAN {
-									if pos >= l {
-										return 0, io.ErrUnexpectedEOF
+
+									b_, err := util.ParseByte(data, &pos)
+									if err != nil {
+										return 0, err
 									}
-									b_ = data[pos]
-									pos++
+									_ = b_
+
 								} else {
 									return 0, fmt.Errorf("nested objects not implemented. ")
 								}

--- a/parser/types/monitor_enter.go
+++ b/parser/types/monitor_enter.go
@@ -4,9 +4,9 @@ package types
 
 import (
 	"fmt"
+
 	"github.com/grafana/jfr-parser/parser/types/def"
-	"io"
-	"unsafe"
+	"github.com/grafana/jfr-parser/util"
 )
 
 type BindJavaMonitorEnter struct {
@@ -94,54 +94,27 @@ type JavaMonitorEnter struct {
 }
 
 func (this *JavaMonitorEnter) Parse(data []byte, bind *BindJavaMonitorEnter, typeMap *def.TypeMap) (pos int, err error) {
-	var (
-		v64_  uint64
-		v32_  uint32
-		s_    string
-		b_    byte
-		shift = uint(0)
-		l     = len(data)
-	)
-	_ = v64_
-	_ = v32_
-	_ = s_
 	for bindFieldIndex := 0; bindFieldIndex < len(bind.Fields); bindFieldIndex++ {
 		bindArraySize := 1
 		if bind.Fields[bindFieldIndex].Field.Array {
-			v32_ = uint32(0)
-			for shift = uint(0); ; shift += 7 {
-				if shift >= 32 {
-					return 0, def.ErrIntOverflow
-				}
-				if pos >= l {
-					return 0, io.ErrUnexpectedEOF
-				}
-				b_ = data[pos]
-				pos++
-				v32_ |= uint32(b_&0x7F) << shift
-				if b_ < 0x80 {
-					break
-				}
+
+			v32_, err := util.ParseVarInt(data, &pos)
+			if err != nil {
+				return 0, err
 			}
+			_ = v32_
+
 			bindArraySize = int(v32_)
 		}
 		for bindArrayIndex := 0; bindArrayIndex < bindArraySize; bindArrayIndex++ {
 			if bind.Fields[bindFieldIndex].Field.ConstantPool {
-				v32_ = uint32(0)
-				for shift = uint(0); ; shift += 7 {
-					if shift >= 32 {
-						return 0, def.ErrIntOverflow
-					}
-					if pos >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b_ = data[pos]
-					pos++
-					v32_ |= uint32(b_&0x7F) << shift
-					if b_ < 0x80 {
-						break
-					}
+
+				v32_, err := util.ParseVarInt(data, &pos)
+				if err != nil {
+					return 0, err
 				}
+				_ = v32_
+
 				switch bind.Fields[bindFieldIndex].Field.Type {
 				case typeMap.T_THREAD:
 					if bind.Fields[bindFieldIndex].ThreadRef != nil {
@@ -160,104 +133,51 @@ func (this *JavaMonitorEnter) Parse(data []byte, bind *BindJavaMonitorEnter, typ
 				bindFieldTypeID := bind.Fields[bindFieldIndex].Field.Type
 				switch bindFieldTypeID {
 				case typeMap.T_STRING:
-					s_ = ""
-					if pos >= l {
-						return 0, io.ErrUnexpectedEOF
+
+					s_, err := util.ParseString(data, &pos)
+					if err != nil {
+						return 0, err
 					}
-					b_ = data[pos]
-					pos++
-					switch b_ {
-					case 0:
-						break
-					case 1:
-						break
-					case 3:
-						v32_ = uint32(0)
-						for shift = uint(0); ; shift += 7 {
-							if shift >= 32 {
-								return 0, def.ErrIntOverflow
-							}
-							if pos >= l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							b_ = data[pos]
-							pos++
-							v32_ |= uint32(b_&0x7F) << shift
-							if b_ < 0x80 {
-								break
-							}
-						}
-						if pos+int(v32_) > l {
-							return 0, io.ErrUnexpectedEOF
-						}
-						bs := data[pos : pos+int(v32_)]
-						s_ = *(*string)(unsafe.Pointer(&bs))
-						pos += int(v32_)
-					default:
-						return 0, fmt.Errorf("unknown string type %d at %d", b_, pos)
-					}
+					_ = s_
+
 					// skipping
 				case typeMap.T_INT:
-					v32_ = uint32(0)
-					for shift = uint(0); ; shift += 7 {
-						if shift >= 32 {
-							return 0, def.ErrIntOverflow
-						}
-						if pos >= l {
-							return 0, io.ErrUnexpectedEOF
-						}
-						b_ = data[pos]
-						pos++
-						v32_ |= uint32(b_&0x7F) << shift
-						if b_ < 0x80 {
-							break
-						}
+
+					v32_, err := util.ParseVarInt(data, &pos)
+					if err != nil {
+						return 0, err
 					}
+					_ = v32_
+
 					// skipping
 				case typeMap.T_LONG:
-					v64_ = 0
-					for shift = uint(0); shift <= 56; shift += 7 {
-						if pos >= l {
-							return 0, io.ErrUnexpectedEOF
-						}
-						b_ = data[pos]
-						pos++
-						if shift == 56 {
-							v64_ |= uint64(b_&0xFF) << shift
-							break
-						} else {
-							v64_ |= uint64(b_&0x7F) << shift
-							if b_ < 0x80 {
-								break
-							}
-						}
+
+					v64_, err := util.ParseVarLong(data, &pos)
+					if err != nil {
+						return 0, err
 					}
+					_ = v64_
+
 					if bind.Fields[bindFieldIndex].uint64 != nil {
 						*bind.Fields[bindFieldIndex].uint64 = v64_
 					}
 				case typeMap.T_BOOLEAN:
-					if pos >= l {
-						return 0, io.ErrUnexpectedEOF
+
+					b_, err := util.ParseByte(data, &pos)
+					if err != nil {
+						return 0, err
 					}
-					b_ = data[pos]
-					pos++
+					_ = b_
+
 					// skipping
 				case typeMap.T_FLOAT:
-					v32_ = uint32(0)
-					for shift = uint(0); ; shift += 7 {
-						if shift >= 32 {
-							return 0, def.ErrIntOverflow
-						}
-						if pos >= l {
-							return 0, io.ErrUnexpectedEOF
-						}
-						b_ = data[pos]
-						pos++
-						v32_ |= uint32(b_&0x7F) << shift
-						if b_ < 0x80 {
-							break
-						}
+
+					v32_, err := util.ParseVarInt(data, &pos)
+					if err != nil {
+						return 0, err
 					}
+					_ = v32_
+
 					// skipping
 				default:
 					bindFieldType := typeMap.IDMap[bind.Fields[bindFieldIndex].Field.Type]
@@ -266,135 +186,66 @@ func (this *JavaMonitorEnter) Parse(data []byte, bind *BindJavaMonitorEnter, typ
 					}
 					bindSkipObjects := 1
 					if bind.Fields[bindFieldIndex].Field.Array {
-						v32_ = uint32(0)
-						for shift = uint(0); ; shift += 7 {
-							if shift >= 32 {
-								return 0, def.ErrIntOverflow
-							}
-							if pos >= l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							b_ = data[pos]
-							pos++
-							v32_ |= uint32(b_&0x7F) << shift
-							if b_ < 0x80 {
-								break
-							}
+
+						v32_, err := util.ParseVarInt(data, &pos)
+						if err != nil {
+							return 0, err
 						}
+						_ = v32_
+
 						bindSkipObjects = int(v32_)
 					}
 					for bindSkipObjectIndex := 0; bindSkipObjectIndex < bindSkipObjects; bindSkipObjectIndex++ {
 						for bindskipFieldIndex := 0; bindskipFieldIndex < len(bindFieldType.Fields); bindskipFieldIndex++ {
 							bindSkipFieldType := bindFieldType.Fields[bindskipFieldIndex].Type
 							if bindFieldType.Fields[bindskipFieldIndex].ConstantPool {
-								v32_ = uint32(0)
-								for shift = uint(0); ; shift += 7 {
-									if shift >= 32 {
-										return 0, def.ErrIntOverflow
-									}
-									if pos >= l {
-										return 0, io.ErrUnexpectedEOF
-									}
-									b_ = data[pos]
-									pos++
-									v32_ |= uint32(b_&0x7F) << shift
-									if b_ < 0x80 {
-										break
-									}
+
+								v32_, err := util.ParseVarInt(data, &pos)
+								if err != nil {
+									return 0, err
 								}
+								_ = v32_
+
 							} else if bindSkipFieldType == typeMap.T_STRING {
-								s_ = ""
-								if pos >= l {
-									return 0, io.ErrUnexpectedEOF
+
+								s_, err := util.ParseString(data, &pos)
+								if err != nil {
+									return 0, err
 								}
-								b_ = data[pos]
-								pos++
-								switch b_ {
-								case 0:
-									break
-								case 1:
-									break
-								case 3:
-									v32_ = uint32(0)
-									for shift = uint(0); ; shift += 7 {
-										if shift >= 32 {
-											return 0, def.ErrIntOverflow
-										}
-										if pos >= l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										b_ = data[pos]
-										pos++
-										v32_ |= uint32(b_&0x7F) << shift
-										if b_ < 0x80 {
-											break
-										}
-									}
-									if pos+int(v32_) > l {
-										return 0, io.ErrUnexpectedEOF
-									}
-									bs := data[pos : pos+int(v32_)]
-									s_ = *(*string)(unsafe.Pointer(&bs))
-									pos += int(v32_)
-								default:
-									return 0, fmt.Errorf("unknown string type %d at %d", b_, pos)
-								}
+								_ = s_
+
 							} else if bindSkipFieldType == typeMap.T_INT {
-								v32_ = uint32(0)
-								for shift = uint(0); ; shift += 7 {
-									if shift >= 32 {
-										return 0, def.ErrIntOverflow
-									}
-									if pos >= l {
-										return 0, io.ErrUnexpectedEOF
-									}
-									b_ = data[pos]
-									pos++
-									v32_ |= uint32(b_&0x7F) << shift
-									if b_ < 0x80 {
-										break
-									}
+
+								v32_, err := util.ParseVarInt(data, &pos)
+								if err != nil {
+									return 0, err
 								}
+								_ = v32_
+
 							} else if bindSkipFieldType == typeMap.T_FLOAT {
-								v32_ = uint32(0)
-								for shift = uint(0); ; shift += 7 {
-									if shift >= 32 {
-										return 0, def.ErrIntOverflow
-									}
-									if pos >= l {
-										return 0, io.ErrUnexpectedEOF
-									}
-									b_ = data[pos]
-									pos++
-									v32_ |= uint32(b_&0x7F) << shift
-									if b_ < 0x80 {
-										break
-									}
+
+								v32_, err := util.ParseVarInt(data, &pos)
+								if err != nil {
+									return 0, err
 								}
+								_ = v32_
+
 							} else if bindSkipFieldType == typeMap.T_LONG {
-								v64_ = 0
-								for shift = uint(0); shift <= 56; shift += 7 {
-									if pos >= l {
-										return 0, io.ErrUnexpectedEOF
-									}
-									b_ = data[pos]
-									pos++
-									if shift == 56 {
-										v64_ |= uint64(b_&0xFF) << shift
-										break
-									} else {
-										v64_ |= uint64(b_&0x7F) << shift
-										if b_ < 0x80 {
-											break
-										}
-									}
+
+								v64_, err := util.ParseVarLong(data, &pos)
+								if err != nil {
+									return 0, err
 								}
+								_ = v64_
+
 							} else if bindSkipFieldType == typeMap.T_BOOLEAN {
-								if pos >= l {
-									return 0, io.ErrUnexpectedEOF
+
+								b_, err := util.ParseByte(data, &pos)
+								if err != nil {
+									return 0, err
 								}
-								b_ = data[pos]
-								pos++
+								_ = b_
+
 							} else {
 								return 0, fmt.Errorf("nested objects not implemented. ")
 							}

--- a/parser/types/package.go
+++ b/parser/types/package.go
@@ -4,9 +4,9 @@ package types
 
 import (
 	"fmt"
+
 	"github.com/grafana/jfr-parser/parser/types/def"
-	"io"
-	"unsafe"
+	"github.com/grafana/jfr-parser/util"
 )
 
 type BindPackage struct {
@@ -48,89 +48,46 @@ type Package struct {
 }
 
 func (this *PackageList) Parse(data []byte, bind *BindPackage, typeMap *def.TypeMap) (pos int, err error) {
-	var (
-		v64_  uint64
-		v32_  uint32
-		s_    string
-		b_    byte
-		shift = uint(0)
-		l     = len(data)
-	)
-	_ = v64_
-	_ = v32_
-	_ = s_
-	v32_ = uint32(0)
-	for shift = uint(0); ; shift += 7 {
-		if shift >= 32 {
-			return 0, def.ErrIntOverflow
-		}
-		if pos >= l {
-			return 0, io.ErrUnexpectedEOF
-		}
-		b_ = data[pos]
-		pos++
-		v32_ |= uint32(b_&0x7F) << shift
-		if b_ < 0x80 {
-			break
-		}
+
+	v32_, err := util.ParseVarInt(data, &pos)
+	if err != nil {
+		return 0, err
 	}
+	_ = v32_
+
 	n := int(v32_)
 	this.IDMap = make(map[PackageRef]uint32, n)
 	this.Package = make([]Package, n)
 	for i := 0; i < n; i++ {
-		v32_ = uint32(0)
-		for shift = uint(0); ; shift += 7 {
-			if shift >= 32 {
-				return 0, def.ErrIntOverflow
-			}
-			if pos >= l {
-				return 0, io.ErrUnexpectedEOF
-			}
-			b_ = data[pos]
-			pos++
-			v32_ |= uint32(b_&0x7F) << shift
-			if b_ < 0x80 {
-				break
-			}
+
+		v32_, err := util.ParseVarInt(data, &pos)
+		if err != nil {
+			return 0, err
 		}
+		_ = v32_
+
 		id := PackageRef(v32_)
 		for bindFieldIndex := 0; bindFieldIndex < len(bind.Fields); bindFieldIndex++ {
 			bindArraySize := 1
 			if bind.Fields[bindFieldIndex].Field.Array {
-				v32_ = uint32(0)
-				for shift = uint(0); ; shift += 7 {
-					if shift >= 32 {
-						return 0, def.ErrIntOverflow
-					}
-					if pos >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b_ = data[pos]
-					pos++
-					v32_ |= uint32(b_&0x7F) << shift
-					if b_ < 0x80 {
-						break
-					}
+
+				v32_, err := util.ParseVarInt(data, &pos)
+				if err != nil {
+					return 0, err
 				}
+				_ = v32_
+
 				bindArraySize = int(v32_)
 			}
 			for bindArrayIndex := 0; bindArrayIndex < bindArraySize; bindArrayIndex++ {
 				if bind.Fields[bindFieldIndex].Field.ConstantPool {
-					v32_ = uint32(0)
-					for shift = uint(0); ; shift += 7 {
-						if shift >= 32 {
-							return 0, def.ErrIntOverflow
-						}
-						if pos >= l {
-							return 0, io.ErrUnexpectedEOF
-						}
-						b_ = data[pos]
-						pos++
-						v32_ |= uint32(b_&0x7F) << shift
-						if b_ < 0x80 {
-							break
-						}
+
+					v32_, err := util.ParseVarInt(data, &pos)
+					if err != nil {
+						return 0, err
 					}
+					_ = v32_
+
 					switch bind.Fields[bindFieldIndex].Field.Type {
 					case typeMap.T_SYMBOL:
 						if bind.Fields[bindFieldIndex].SymbolRef != nil {
@@ -141,102 +98,49 @@ func (this *PackageList) Parse(data []byte, bind *BindPackage, typeMap *def.Type
 					bindFieldTypeID := bind.Fields[bindFieldIndex].Field.Type
 					switch bindFieldTypeID {
 					case typeMap.T_STRING:
-						s_ = ""
-						if pos >= l {
-							return 0, io.ErrUnexpectedEOF
+
+						s_, err := util.ParseString(data, &pos)
+						if err != nil {
+							return 0, err
 						}
-						b_ = data[pos]
-						pos++
-						switch b_ {
-						case 0:
-							break
-						case 1:
-							break
-						case 3:
-							v32_ = uint32(0)
-							for shift = uint(0); ; shift += 7 {
-								if shift >= 32 {
-									return 0, def.ErrIntOverflow
-								}
-								if pos >= l {
-									return 0, io.ErrUnexpectedEOF
-								}
-								b_ = data[pos]
-								pos++
-								v32_ |= uint32(b_&0x7F) << shift
-								if b_ < 0x80 {
-									break
-								}
-							}
-							if pos+int(v32_) > l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							bs := data[pos : pos+int(v32_)]
-							s_ = *(*string)(unsafe.Pointer(&bs))
-							pos += int(v32_)
-						default:
-							return 0, fmt.Errorf("unknown string type %d at %d", b_, pos)
-						}
+						_ = s_
+
 						// skipping
 					case typeMap.T_INT:
-						v32_ = uint32(0)
-						for shift = uint(0); ; shift += 7 {
-							if shift >= 32 {
-								return 0, def.ErrIntOverflow
-							}
-							if pos >= l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							b_ = data[pos]
-							pos++
-							v32_ |= uint32(b_&0x7F) << shift
-							if b_ < 0x80 {
-								break
-							}
+
+						v32_, err := util.ParseVarInt(data, &pos)
+						if err != nil {
+							return 0, err
 						}
+						_ = v32_
+
 						// skipping
 					case typeMap.T_LONG:
-						v64_ = 0
-						for shift = uint(0); shift <= 56; shift += 7 {
-							if pos >= l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							b_ = data[pos]
-							pos++
-							if shift == 56 {
-								v64_ |= uint64(b_&0xFF) << shift
-								break
-							} else {
-								v64_ |= uint64(b_&0x7F) << shift
-								if b_ < 0x80 {
-									break
-								}
-							}
+
+						v64_, err := util.ParseVarLong(data, &pos)
+						if err != nil {
+							return 0, err
 						}
+						_ = v64_
+
 						// skipping
 					case typeMap.T_BOOLEAN:
-						if pos >= l {
-							return 0, io.ErrUnexpectedEOF
+
+						b_, err := util.ParseByte(data, &pos)
+						if err != nil {
+							return 0, err
 						}
-						b_ = data[pos]
-						pos++
+						_ = b_
+
 						// skipping
 					case typeMap.T_FLOAT:
-						v32_ = uint32(0)
-						for shift = uint(0); ; shift += 7 {
-							if shift >= 32 {
-								return 0, def.ErrIntOverflow
-							}
-							if pos >= l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							b_ = data[pos]
-							pos++
-							v32_ |= uint32(b_&0x7F) << shift
-							if b_ < 0x80 {
-								break
-							}
+
+						v32_, err := util.ParseVarInt(data, &pos)
+						if err != nil {
+							return 0, err
 						}
+						_ = v32_
+
 						// skipping
 					default:
 						bindFieldType := typeMap.IDMap[bind.Fields[bindFieldIndex].Field.Type]
@@ -245,135 +149,66 @@ func (this *PackageList) Parse(data []byte, bind *BindPackage, typeMap *def.Type
 						}
 						bindSkipObjects := 1
 						if bind.Fields[bindFieldIndex].Field.Array {
-							v32_ = uint32(0)
-							for shift = uint(0); ; shift += 7 {
-								if shift >= 32 {
-									return 0, def.ErrIntOverflow
-								}
-								if pos >= l {
-									return 0, io.ErrUnexpectedEOF
-								}
-								b_ = data[pos]
-								pos++
-								v32_ |= uint32(b_&0x7F) << shift
-								if b_ < 0x80 {
-									break
-								}
+
+							v32_, err := util.ParseVarInt(data, &pos)
+							if err != nil {
+								return 0, err
 							}
+							_ = v32_
+
 							bindSkipObjects = int(v32_)
 						}
 						for bindSkipObjectIndex := 0; bindSkipObjectIndex < bindSkipObjects; bindSkipObjectIndex++ {
 							for bindskipFieldIndex := 0; bindskipFieldIndex < len(bindFieldType.Fields); bindskipFieldIndex++ {
 								bindSkipFieldType := bindFieldType.Fields[bindskipFieldIndex].Type
 								if bindFieldType.Fields[bindskipFieldIndex].ConstantPool {
-									v32_ = uint32(0)
-									for shift = uint(0); ; shift += 7 {
-										if shift >= 32 {
-											return 0, def.ErrIntOverflow
-										}
-										if pos >= l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										b_ = data[pos]
-										pos++
-										v32_ |= uint32(b_&0x7F) << shift
-										if b_ < 0x80 {
-											break
-										}
+
+									v32_, err := util.ParseVarInt(data, &pos)
+									if err != nil {
+										return 0, err
 									}
+									_ = v32_
+
 								} else if bindSkipFieldType == typeMap.T_STRING {
-									s_ = ""
-									if pos >= l {
-										return 0, io.ErrUnexpectedEOF
+
+									s_, err := util.ParseString(data, &pos)
+									if err != nil {
+										return 0, err
 									}
-									b_ = data[pos]
-									pos++
-									switch b_ {
-									case 0:
-										break
-									case 1:
-										break
-									case 3:
-										v32_ = uint32(0)
-										for shift = uint(0); ; shift += 7 {
-											if shift >= 32 {
-												return 0, def.ErrIntOverflow
-											}
-											if pos >= l {
-												return 0, io.ErrUnexpectedEOF
-											}
-											b_ = data[pos]
-											pos++
-											v32_ |= uint32(b_&0x7F) << shift
-											if b_ < 0x80 {
-												break
-											}
-										}
-										if pos+int(v32_) > l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										bs := data[pos : pos+int(v32_)]
-										s_ = *(*string)(unsafe.Pointer(&bs))
-										pos += int(v32_)
-									default:
-										return 0, fmt.Errorf("unknown string type %d at %d", b_, pos)
-									}
+									_ = s_
+
 								} else if bindSkipFieldType == typeMap.T_INT {
-									v32_ = uint32(0)
-									for shift = uint(0); ; shift += 7 {
-										if shift >= 32 {
-											return 0, def.ErrIntOverflow
-										}
-										if pos >= l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										b_ = data[pos]
-										pos++
-										v32_ |= uint32(b_&0x7F) << shift
-										if b_ < 0x80 {
-											break
-										}
+
+									v32_, err := util.ParseVarInt(data, &pos)
+									if err != nil {
+										return 0, err
 									}
+									_ = v32_
+
 								} else if bindSkipFieldType == typeMap.T_FLOAT {
-									v32_ = uint32(0)
-									for shift = uint(0); ; shift += 7 {
-										if shift >= 32 {
-											return 0, def.ErrIntOverflow
-										}
-										if pos >= l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										b_ = data[pos]
-										pos++
-										v32_ |= uint32(b_&0x7F) << shift
-										if b_ < 0x80 {
-											break
-										}
+
+									v32_, err := util.ParseVarInt(data, &pos)
+									if err != nil {
+										return 0, err
 									}
+									_ = v32_
+
 								} else if bindSkipFieldType == typeMap.T_LONG {
-									v64_ = 0
-									for shift = uint(0); shift <= 56; shift += 7 {
-										if pos >= l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										b_ = data[pos]
-										pos++
-										if shift == 56 {
-											v64_ |= uint64(b_&0xFF) << shift
-											break
-										} else {
-											v64_ |= uint64(b_&0x7F) << shift
-											if b_ < 0x80 {
-												break
-											}
-										}
+
+									v64_, err := util.ParseVarLong(data, &pos)
+									if err != nil {
+										return 0, err
 									}
+									_ = v64_
+
 								} else if bindSkipFieldType == typeMap.T_BOOLEAN {
-									if pos >= l {
-										return 0, io.ErrUnexpectedEOF
+
+									b_, err := util.ParseByte(data, &pos)
+									if err != nil {
+										return 0, err
 									}
-									b_ = data[pos]
-									pos++
+									_ = b_
+
 								} else {
 									return 0, fmt.Errorf("nested objects not implemented. ")
 								}

--- a/parser/types/stackframe.go
+++ b/parser/types/stackframe.go
@@ -4,9 +4,9 @@ package types
 
 import (
 	"fmt"
+
 	"github.com/grafana/jfr-parser/parser/types/def"
-	"io"
-	"unsafe"
+	"github.com/grafana/jfr-parser/util"
 )
 
 type BindStackFrame struct {
@@ -57,54 +57,27 @@ type StackFrame struct {
 }
 
 func (this *StackFrame) Parse(data []byte, bind *BindStackFrame, typeMap *def.TypeMap) (pos int, err error) {
-	var (
-		v64_  uint64
-		v32_  uint32
-		s_    string
-		b_    byte
-		shift = uint(0)
-		l     = len(data)
-	)
-	_ = v64_
-	_ = v32_
-	_ = s_
 	for bindFieldIndex := 0; bindFieldIndex < len(bind.Fields); bindFieldIndex++ {
 		bindArraySize := 1
 		if bind.Fields[bindFieldIndex].Field.Array {
-			v32_ = uint32(0)
-			for shift = uint(0); ; shift += 7 {
-				if shift >= 32 {
-					return 0, def.ErrIntOverflow
-				}
-				if pos >= l {
-					return 0, io.ErrUnexpectedEOF
-				}
-				b_ = data[pos]
-				pos++
-				v32_ |= uint32(b_&0x7F) << shift
-				if b_ < 0x80 {
-					break
-				}
+
+			v32_, err := util.ParseVarInt(data, &pos)
+			if err != nil {
+				return 0, err
 			}
+			_ = v32_
+
 			bindArraySize = int(v32_)
 		}
 		for bindArrayIndex := 0; bindArrayIndex < bindArraySize; bindArrayIndex++ {
 			if bind.Fields[bindFieldIndex].Field.ConstantPool {
-				v32_ = uint32(0)
-				for shift = uint(0); ; shift += 7 {
-					if shift >= 32 {
-						return 0, def.ErrIntOverflow
-					}
-					if pos >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b_ = data[pos]
-					pos++
-					v32_ |= uint32(b_&0x7F) << shift
-					if b_ < 0x80 {
-						break
-					}
+
+				v32_, err := util.ParseVarInt(data, &pos)
+				if err != nil {
+					return 0, err
 				}
+				_ = v32_
+
 				switch bind.Fields[bindFieldIndex].Field.Type {
 				case typeMap.T_METHOD:
 					if bind.Fields[bindFieldIndex].MethodRef != nil {
@@ -119,104 +92,51 @@ func (this *StackFrame) Parse(data []byte, bind *BindStackFrame, typeMap *def.Ty
 				bindFieldTypeID := bind.Fields[bindFieldIndex].Field.Type
 				switch bindFieldTypeID {
 				case typeMap.T_STRING:
-					s_ = ""
-					if pos >= l {
-						return 0, io.ErrUnexpectedEOF
+
+					s_, err := util.ParseString(data, &pos)
+					if err != nil {
+						return 0, err
 					}
-					b_ = data[pos]
-					pos++
-					switch b_ {
-					case 0:
-						break
-					case 1:
-						break
-					case 3:
-						v32_ = uint32(0)
-						for shift = uint(0); ; shift += 7 {
-							if shift >= 32 {
-								return 0, def.ErrIntOverflow
-							}
-							if pos >= l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							b_ = data[pos]
-							pos++
-							v32_ |= uint32(b_&0x7F) << shift
-							if b_ < 0x80 {
-								break
-							}
-						}
-						if pos+int(v32_) > l {
-							return 0, io.ErrUnexpectedEOF
-						}
-						bs := data[pos : pos+int(v32_)]
-						s_ = *(*string)(unsafe.Pointer(&bs))
-						pos += int(v32_)
-					default:
-						return 0, fmt.Errorf("unknown string type %d at %d", b_, pos)
-					}
+					_ = s_
+
 					// skipping
 				case typeMap.T_INT:
-					v32_ = uint32(0)
-					for shift = uint(0); ; shift += 7 {
-						if shift >= 32 {
-							return 0, def.ErrIntOverflow
-						}
-						if pos >= l {
-							return 0, io.ErrUnexpectedEOF
-						}
-						b_ = data[pos]
-						pos++
-						v32_ |= uint32(b_&0x7F) << shift
-						if b_ < 0x80 {
-							break
-						}
+
+					v32_, err := util.ParseVarInt(data, &pos)
+					if err != nil {
+						return 0, err
 					}
+					_ = v32_
+
 					if bind.Fields[bindFieldIndex].uint32 != nil {
 						*bind.Fields[bindFieldIndex].uint32 = v32_
 					}
 				case typeMap.T_LONG:
-					v64_ = 0
-					for shift = uint(0); shift <= 56; shift += 7 {
-						if pos >= l {
-							return 0, io.ErrUnexpectedEOF
-						}
-						b_ = data[pos]
-						pos++
-						if shift == 56 {
-							v64_ |= uint64(b_&0xFF) << shift
-							break
-						} else {
-							v64_ |= uint64(b_&0x7F) << shift
-							if b_ < 0x80 {
-								break
-							}
-						}
+
+					v64_, err := util.ParseVarLong(data, &pos)
+					if err != nil {
+						return 0, err
 					}
+					_ = v64_
+
 					// skipping
 				case typeMap.T_BOOLEAN:
-					if pos >= l {
-						return 0, io.ErrUnexpectedEOF
+
+					b_, err := util.ParseByte(data, &pos)
+					if err != nil {
+						return 0, err
 					}
-					b_ = data[pos]
-					pos++
+					_ = b_
+
 					// skipping
 				case typeMap.T_FLOAT:
-					v32_ = uint32(0)
-					for shift = uint(0); ; shift += 7 {
-						if shift >= 32 {
-							return 0, def.ErrIntOverflow
-						}
-						if pos >= l {
-							return 0, io.ErrUnexpectedEOF
-						}
-						b_ = data[pos]
-						pos++
-						v32_ |= uint32(b_&0x7F) << shift
-						if b_ < 0x80 {
-							break
-						}
+
+					v32_, err := util.ParseVarInt(data, &pos)
+					if err != nil {
+						return 0, err
 					}
+					_ = v32_
+
 					// skipping
 				default:
 					bindFieldType := typeMap.IDMap[bind.Fields[bindFieldIndex].Field.Type]
@@ -225,135 +145,66 @@ func (this *StackFrame) Parse(data []byte, bind *BindStackFrame, typeMap *def.Ty
 					}
 					bindSkipObjects := 1
 					if bind.Fields[bindFieldIndex].Field.Array {
-						v32_ = uint32(0)
-						for shift = uint(0); ; shift += 7 {
-							if shift >= 32 {
-								return 0, def.ErrIntOverflow
-							}
-							if pos >= l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							b_ = data[pos]
-							pos++
-							v32_ |= uint32(b_&0x7F) << shift
-							if b_ < 0x80 {
-								break
-							}
+
+						v32_, err := util.ParseVarInt(data, &pos)
+						if err != nil {
+							return 0, err
 						}
+						_ = v32_
+
 						bindSkipObjects = int(v32_)
 					}
 					for bindSkipObjectIndex := 0; bindSkipObjectIndex < bindSkipObjects; bindSkipObjectIndex++ {
 						for bindskipFieldIndex := 0; bindskipFieldIndex < len(bindFieldType.Fields); bindskipFieldIndex++ {
 							bindSkipFieldType := bindFieldType.Fields[bindskipFieldIndex].Type
 							if bindFieldType.Fields[bindskipFieldIndex].ConstantPool {
-								v32_ = uint32(0)
-								for shift = uint(0); ; shift += 7 {
-									if shift >= 32 {
-										return 0, def.ErrIntOverflow
-									}
-									if pos >= l {
-										return 0, io.ErrUnexpectedEOF
-									}
-									b_ = data[pos]
-									pos++
-									v32_ |= uint32(b_&0x7F) << shift
-									if b_ < 0x80 {
-										break
-									}
+
+								v32_, err := util.ParseVarInt(data, &pos)
+								if err != nil {
+									return 0, err
 								}
+								_ = v32_
+
 							} else if bindSkipFieldType == typeMap.T_STRING {
-								s_ = ""
-								if pos >= l {
-									return 0, io.ErrUnexpectedEOF
+
+								s_, err := util.ParseString(data, &pos)
+								if err != nil {
+									return 0, err
 								}
-								b_ = data[pos]
-								pos++
-								switch b_ {
-								case 0:
-									break
-								case 1:
-									break
-								case 3:
-									v32_ = uint32(0)
-									for shift = uint(0); ; shift += 7 {
-										if shift >= 32 {
-											return 0, def.ErrIntOverflow
-										}
-										if pos >= l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										b_ = data[pos]
-										pos++
-										v32_ |= uint32(b_&0x7F) << shift
-										if b_ < 0x80 {
-											break
-										}
-									}
-									if pos+int(v32_) > l {
-										return 0, io.ErrUnexpectedEOF
-									}
-									bs := data[pos : pos+int(v32_)]
-									s_ = *(*string)(unsafe.Pointer(&bs))
-									pos += int(v32_)
-								default:
-									return 0, fmt.Errorf("unknown string type %d at %d", b_, pos)
-								}
+								_ = s_
+
 							} else if bindSkipFieldType == typeMap.T_INT {
-								v32_ = uint32(0)
-								for shift = uint(0); ; shift += 7 {
-									if shift >= 32 {
-										return 0, def.ErrIntOverflow
-									}
-									if pos >= l {
-										return 0, io.ErrUnexpectedEOF
-									}
-									b_ = data[pos]
-									pos++
-									v32_ |= uint32(b_&0x7F) << shift
-									if b_ < 0x80 {
-										break
-									}
+
+								v32_, err := util.ParseVarInt(data, &pos)
+								if err != nil {
+									return 0, err
 								}
+								_ = v32_
+
 							} else if bindSkipFieldType == typeMap.T_FLOAT {
-								v32_ = uint32(0)
-								for shift = uint(0); ; shift += 7 {
-									if shift >= 32 {
-										return 0, def.ErrIntOverflow
-									}
-									if pos >= l {
-										return 0, io.ErrUnexpectedEOF
-									}
-									b_ = data[pos]
-									pos++
-									v32_ |= uint32(b_&0x7F) << shift
-									if b_ < 0x80 {
-										break
-									}
+
+								v32_, err := util.ParseVarInt(data, &pos)
+								if err != nil {
+									return 0, err
 								}
+								_ = v32_
+
 							} else if bindSkipFieldType == typeMap.T_LONG {
-								v64_ = 0
-								for shift = uint(0); shift <= 56; shift += 7 {
-									if pos >= l {
-										return 0, io.ErrUnexpectedEOF
-									}
-									b_ = data[pos]
-									pos++
-									if shift == 56 {
-										v64_ |= uint64(b_&0xFF) << shift
-										break
-									} else {
-										v64_ |= uint64(b_&0x7F) << shift
-										if b_ < 0x80 {
-											break
-										}
-									}
+
+								v64_, err := util.ParseVarLong(data, &pos)
+								if err != nil {
+									return 0, err
 								}
+								_ = v64_
+
 							} else if bindSkipFieldType == typeMap.T_BOOLEAN {
-								if pos >= l {
-									return 0, io.ErrUnexpectedEOF
+
+								b_, err := util.ParseByte(data, &pos)
+								if err != nil {
+									return 0, err
 								}
-								b_ = data[pos]
-								pos++
+								_ = b_
+
 							} else {
 								return 0, fmt.Errorf("nested objects not implemented. ")
 							}

--- a/parser/types/symbol.go
+++ b/parser/types/symbol.go
@@ -4,9 +4,9 @@ package types
 
 import (
 	"fmt"
+
 	"github.com/grafana/jfr-parser/parser/types/def"
-	"io"
-	"unsafe"
+	"github.com/grafana/jfr-parser/util"
 )
 
 type BindSymbol struct {
@@ -48,191 +48,95 @@ type Symbol struct {
 }
 
 func (this *SymbolList) Parse(data []byte, bind *BindSymbol, typeMap *def.TypeMap) (pos int, err error) {
-	var (
-		v64_  uint64
-		v32_  uint32
-		s_    string
-		b_    byte
-		shift = uint(0)
-		l     = len(data)
-	)
-	_ = v64_
-	_ = v32_
-	_ = s_
-	v32_ = uint32(0)
-	for shift = uint(0); ; shift += 7 {
-		if shift >= 32 {
-			return 0, def.ErrIntOverflow
-		}
-		if pos >= l {
-			return 0, io.ErrUnexpectedEOF
-		}
-		b_ = data[pos]
-		pos++
-		v32_ |= uint32(b_&0x7F) << shift
-		if b_ < 0x80 {
-			break
-		}
+
+	v32_, err := util.ParseVarInt(data, &pos)
+	if err != nil {
+		return 0, err
 	}
+	_ = v32_
+
 	n := int(v32_)
 	this.IDMap = make(map[SymbolRef]uint32, n)
 	this.Symbol = make([]Symbol, n)
 	for i := 0; i < n; i++ {
-		v32_ = uint32(0)
-		for shift = uint(0); ; shift += 7 {
-			if shift >= 32 {
-				return 0, def.ErrIntOverflow
-			}
-			if pos >= l {
-				return 0, io.ErrUnexpectedEOF
-			}
-			b_ = data[pos]
-			pos++
-			v32_ |= uint32(b_&0x7F) << shift
-			if b_ < 0x80 {
-				break
-			}
+
+		v32_, err := util.ParseVarInt(data, &pos)
+		if err != nil {
+			return 0, err
 		}
+		_ = v32_
+
 		id := SymbolRef(v32_)
 		for bindFieldIndex := 0; bindFieldIndex < len(bind.Fields); bindFieldIndex++ {
 			bindArraySize := 1
 			if bind.Fields[bindFieldIndex].Field.Array {
-				v32_ = uint32(0)
-				for shift = uint(0); ; shift += 7 {
-					if shift >= 32 {
-						return 0, def.ErrIntOverflow
-					}
-					if pos >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b_ = data[pos]
-					pos++
-					v32_ |= uint32(b_&0x7F) << shift
-					if b_ < 0x80 {
-						break
-					}
+
+				v32_, err := util.ParseVarInt(data, &pos)
+				if err != nil {
+					return 0, err
 				}
+				_ = v32_
+
 				bindArraySize = int(v32_)
 			}
 			for bindArrayIndex := 0; bindArrayIndex < bindArraySize; bindArrayIndex++ {
 				if bind.Fields[bindFieldIndex].Field.ConstantPool {
-					v32_ = uint32(0)
-					for shift = uint(0); ; shift += 7 {
-						if shift >= 32 {
-							return 0, def.ErrIntOverflow
-						}
-						if pos >= l {
-							return 0, io.ErrUnexpectedEOF
-						}
-						b_ = data[pos]
-						pos++
-						v32_ |= uint32(b_&0x7F) << shift
-						if b_ < 0x80 {
-							break
-						}
+
+					v32_, err := util.ParseVarInt(data, &pos)
+					if err != nil {
+						return 0, err
 					}
+					_ = v32_
+
 				} else {
 					bindFieldTypeID := bind.Fields[bindFieldIndex].Field.Type
 					switch bindFieldTypeID {
 					case typeMap.T_STRING:
-						s_ = ""
-						if pos >= l {
-							return 0, io.ErrUnexpectedEOF
+
+						s_, err := util.ParseString(data, &pos)
+						if err != nil {
+							return 0, err
 						}
-						b_ = data[pos]
-						pos++
-						switch b_ {
-						case 0:
-							break
-						case 1:
-							break
-						case 3:
-							v32_ = uint32(0)
-							for shift = uint(0); ; shift += 7 {
-								if shift >= 32 {
-									return 0, def.ErrIntOverflow
-								}
-								if pos >= l {
-									return 0, io.ErrUnexpectedEOF
-								}
-								b_ = data[pos]
-								pos++
-								v32_ |= uint32(b_&0x7F) << shift
-								if b_ < 0x80 {
-									break
-								}
-							}
-							if pos+int(v32_) > l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							bs := data[pos : pos+int(v32_)]
-							s_ = *(*string)(unsafe.Pointer(&bs))
-							pos += int(v32_)
-						default:
-							return 0, fmt.Errorf("unknown string type %d at %d", b_, pos)
-						}
+						_ = s_
+
 						if bind.Fields[bindFieldIndex].string != nil {
 							*bind.Fields[bindFieldIndex].string = s_
 						}
 					case typeMap.T_INT:
-						v32_ = uint32(0)
-						for shift = uint(0); ; shift += 7 {
-							if shift >= 32 {
-								return 0, def.ErrIntOverflow
-							}
-							if pos >= l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							b_ = data[pos]
-							pos++
-							v32_ |= uint32(b_&0x7F) << shift
-							if b_ < 0x80 {
-								break
-							}
+
+						v32_, err := util.ParseVarInt(data, &pos)
+						if err != nil {
+							return 0, err
 						}
+						_ = v32_
+
 						// skipping
 					case typeMap.T_LONG:
-						v64_ = 0
-						for shift = uint(0); shift <= 56; shift += 7 {
-							if pos >= l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							b_ = data[pos]
-							pos++
-							if shift == 56 {
-								v64_ |= uint64(b_&0xFF) << shift
-								break
-							} else {
-								v64_ |= uint64(b_&0x7F) << shift
-								if b_ < 0x80 {
-									break
-								}
-							}
+
+						v64_, err := util.ParseVarLong(data, &pos)
+						if err != nil {
+							return 0, err
 						}
+						_ = v64_
+
 						// skipping
 					case typeMap.T_BOOLEAN:
-						if pos >= l {
-							return 0, io.ErrUnexpectedEOF
+
+						b_, err := util.ParseByte(data, &pos)
+						if err != nil {
+							return 0, err
 						}
-						b_ = data[pos]
-						pos++
+						_ = b_
+
 						// skipping
 					case typeMap.T_FLOAT:
-						v32_ = uint32(0)
-						for shift = uint(0); ; shift += 7 {
-							if shift >= 32 {
-								return 0, def.ErrIntOverflow
-							}
-							if pos >= l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							b_ = data[pos]
-							pos++
-							v32_ |= uint32(b_&0x7F) << shift
-							if b_ < 0x80 {
-								break
-							}
+
+						v32_, err := util.ParseVarInt(data, &pos)
+						if err != nil {
+							return 0, err
 						}
+						_ = v32_
+
 						// skipping
 					default:
 						bindFieldType := typeMap.IDMap[bind.Fields[bindFieldIndex].Field.Type]
@@ -241,135 +145,66 @@ func (this *SymbolList) Parse(data []byte, bind *BindSymbol, typeMap *def.TypeMa
 						}
 						bindSkipObjects := 1
 						if bind.Fields[bindFieldIndex].Field.Array {
-							v32_ = uint32(0)
-							for shift = uint(0); ; shift += 7 {
-								if shift >= 32 {
-									return 0, def.ErrIntOverflow
-								}
-								if pos >= l {
-									return 0, io.ErrUnexpectedEOF
-								}
-								b_ = data[pos]
-								pos++
-								v32_ |= uint32(b_&0x7F) << shift
-								if b_ < 0x80 {
-									break
-								}
+
+							v32_, err := util.ParseVarInt(data, &pos)
+							if err != nil {
+								return 0, err
 							}
+							_ = v32_
+
 							bindSkipObjects = int(v32_)
 						}
 						for bindSkipObjectIndex := 0; bindSkipObjectIndex < bindSkipObjects; bindSkipObjectIndex++ {
 							for bindskipFieldIndex := 0; bindskipFieldIndex < len(bindFieldType.Fields); bindskipFieldIndex++ {
 								bindSkipFieldType := bindFieldType.Fields[bindskipFieldIndex].Type
 								if bindFieldType.Fields[bindskipFieldIndex].ConstantPool {
-									v32_ = uint32(0)
-									for shift = uint(0); ; shift += 7 {
-										if shift >= 32 {
-											return 0, def.ErrIntOverflow
-										}
-										if pos >= l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										b_ = data[pos]
-										pos++
-										v32_ |= uint32(b_&0x7F) << shift
-										if b_ < 0x80 {
-											break
-										}
+
+									v32_, err := util.ParseVarInt(data, &pos)
+									if err != nil {
+										return 0, err
 									}
+									_ = v32_
+
 								} else if bindSkipFieldType == typeMap.T_STRING {
-									s_ = ""
-									if pos >= l {
-										return 0, io.ErrUnexpectedEOF
+
+									s_, err := util.ParseString(data, &pos)
+									if err != nil {
+										return 0, err
 									}
-									b_ = data[pos]
-									pos++
-									switch b_ {
-									case 0:
-										break
-									case 1:
-										break
-									case 3:
-										v32_ = uint32(0)
-										for shift = uint(0); ; shift += 7 {
-											if shift >= 32 {
-												return 0, def.ErrIntOverflow
-											}
-											if pos >= l {
-												return 0, io.ErrUnexpectedEOF
-											}
-											b_ = data[pos]
-											pos++
-											v32_ |= uint32(b_&0x7F) << shift
-											if b_ < 0x80 {
-												break
-											}
-										}
-										if pos+int(v32_) > l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										bs := data[pos : pos+int(v32_)]
-										s_ = *(*string)(unsafe.Pointer(&bs))
-										pos += int(v32_)
-									default:
-										return 0, fmt.Errorf("unknown string type %d at %d", b_, pos)
-									}
+									_ = s_
+
 								} else if bindSkipFieldType == typeMap.T_INT {
-									v32_ = uint32(0)
-									for shift = uint(0); ; shift += 7 {
-										if shift >= 32 {
-											return 0, def.ErrIntOverflow
-										}
-										if pos >= l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										b_ = data[pos]
-										pos++
-										v32_ |= uint32(b_&0x7F) << shift
-										if b_ < 0x80 {
-											break
-										}
+
+									v32_, err := util.ParseVarInt(data, &pos)
+									if err != nil {
+										return 0, err
 									}
+									_ = v32_
+
 								} else if bindSkipFieldType == typeMap.T_FLOAT {
-									v32_ = uint32(0)
-									for shift = uint(0); ; shift += 7 {
-										if shift >= 32 {
-											return 0, def.ErrIntOverflow
-										}
-										if pos >= l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										b_ = data[pos]
-										pos++
-										v32_ |= uint32(b_&0x7F) << shift
-										if b_ < 0x80 {
-											break
-										}
+
+									v32_, err := util.ParseVarInt(data, &pos)
+									if err != nil {
+										return 0, err
 									}
+									_ = v32_
+
 								} else if bindSkipFieldType == typeMap.T_LONG {
-									v64_ = 0
-									for shift = uint(0); shift <= 56; shift += 7 {
-										if pos >= l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										b_ = data[pos]
-										pos++
-										if shift == 56 {
-											v64_ |= uint64(b_&0xFF) << shift
-											break
-										} else {
-											v64_ |= uint64(b_&0x7F) << shift
-											if b_ < 0x80 {
-												break
-											}
-										}
+
+									v64_, err := util.ParseVarLong(data, &pos)
+									if err != nil {
+										return 0, err
 									}
+									_ = v64_
+
 								} else if bindSkipFieldType == typeMap.T_BOOLEAN {
-									if pos >= l {
-										return 0, io.ErrUnexpectedEOF
+
+									b_, err := util.ParseByte(data, &pos)
+									if err != nil {
+										return 0, err
 									}
-									b_ = data[pos]
-									pos++
+									_ = b_
+
 								} else {
 									return 0, fmt.Errorf("nested objects not implemented. ")
 								}

--- a/parser/types/thread.go
+++ b/parser/types/thread.go
@@ -4,9 +4,9 @@ package types
 
 import (
 	"fmt"
+
 	"github.com/grafana/jfr-parser/parser/types/def"
-	"io"
-	"unsafe"
+	"github.com/grafana/jfr-parser/util"
 )
 
 type BindThread struct {
@@ -70,193 +70,97 @@ type Thread struct {
 }
 
 func (this *ThreadList) Parse(data []byte, bind *BindThread, typeMap *def.TypeMap) (pos int, err error) {
-	var (
-		v64_  uint64
-		v32_  uint32
-		s_    string
-		b_    byte
-		shift = uint(0)
-		l     = len(data)
-	)
-	_ = v64_
-	_ = v32_
-	_ = s_
-	v32_ = uint32(0)
-	for shift = uint(0); ; shift += 7 {
-		if shift >= 32 {
-			return 0, def.ErrIntOverflow
-		}
-		if pos >= l {
-			return 0, io.ErrUnexpectedEOF
-		}
-		b_ = data[pos]
-		pos++
-		v32_ |= uint32(b_&0x7F) << shift
-		if b_ < 0x80 {
-			break
-		}
+
+	v32_, err := util.ParseVarInt(data, &pos)
+	if err != nil {
+		return 0, err
 	}
+	_ = v32_
+
 	n := int(v32_)
 	this.IDMap = make(map[ThreadRef]uint32, n)
 	this.Thread = make([]Thread, n)
 	for i := 0; i < n; i++ {
-		v32_ = uint32(0)
-		for shift = uint(0); ; shift += 7 {
-			if shift >= 32 {
-				return 0, def.ErrIntOverflow
-			}
-			if pos >= l {
-				return 0, io.ErrUnexpectedEOF
-			}
-			b_ = data[pos]
-			pos++
-			v32_ |= uint32(b_&0x7F) << shift
-			if b_ < 0x80 {
-				break
-			}
+
+		v32_, err := util.ParseVarInt(data, &pos)
+		if err != nil {
+			return 0, err
 		}
+		_ = v32_
+
 		id := ThreadRef(v32_)
 		for bindFieldIndex := 0; bindFieldIndex < len(bind.Fields); bindFieldIndex++ {
 			bindArraySize := 1
 			if bind.Fields[bindFieldIndex].Field.Array {
-				v32_ = uint32(0)
-				for shift = uint(0); ; shift += 7 {
-					if shift >= 32 {
-						return 0, def.ErrIntOverflow
-					}
-					if pos >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b_ = data[pos]
-					pos++
-					v32_ |= uint32(b_&0x7F) << shift
-					if b_ < 0x80 {
-						break
-					}
+
+				v32_, err := util.ParseVarInt(data, &pos)
+				if err != nil {
+					return 0, err
 				}
+				_ = v32_
+
 				bindArraySize = int(v32_)
 			}
 			for bindArrayIndex := 0; bindArrayIndex < bindArraySize; bindArrayIndex++ {
 				if bind.Fields[bindFieldIndex].Field.ConstantPool {
-					v32_ = uint32(0)
-					for shift = uint(0); ; shift += 7 {
-						if shift >= 32 {
-							return 0, def.ErrIntOverflow
-						}
-						if pos >= l {
-							return 0, io.ErrUnexpectedEOF
-						}
-						b_ = data[pos]
-						pos++
-						v32_ |= uint32(b_&0x7F) << shift
-						if b_ < 0x80 {
-							break
-						}
+
+					v32_, err := util.ParseVarInt(data, &pos)
+					if err != nil {
+						return 0, err
 					}
+					_ = v32_
+
 				} else {
 					bindFieldTypeID := bind.Fields[bindFieldIndex].Field.Type
 					switch bindFieldTypeID {
 					case typeMap.T_STRING:
-						s_ = ""
-						if pos >= l {
-							return 0, io.ErrUnexpectedEOF
+
+						s_, err := util.ParseString(data, &pos)
+						if err != nil {
+							return 0, err
 						}
-						b_ = data[pos]
-						pos++
-						switch b_ {
-						case 0:
-							break
-						case 1:
-							break
-						case 3:
-							v32_ = uint32(0)
-							for shift = uint(0); ; shift += 7 {
-								if shift >= 32 {
-									return 0, def.ErrIntOverflow
-								}
-								if pos >= l {
-									return 0, io.ErrUnexpectedEOF
-								}
-								b_ = data[pos]
-								pos++
-								v32_ |= uint32(b_&0x7F) << shift
-								if b_ < 0x80 {
-									break
-								}
-							}
-							if pos+int(v32_) > l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							bs := data[pos : pos+int(v32_)]
-							s_ = *(*string)(unsafe.Pointer(&bs))
-							pos += int(v32_)
-						default:
-							return 0, fmt.Errorf("unknown string type %d at %d", b_, pos)
-						}
+						_ = s_
+
 						if bind.Fields[bindFieldIndex].string != nil {
 							*bind.Fields[bindFieldIndex].string = s_
 						}
 					case typeMap.T_INT:
-						v32_ = uint32(0)
-						for shift = uint(0); ; shift += 7 {
-							if shift >= 32 {
-								return 0, def.ErrIntOverflow
-							}
-							if pos >= l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							b_ = data[pos]
-							pos++
-							v32_ |= uint32(b_&0x7F) << shift
-							if b_ < 0x80 {
-								break
-							}
+
+						v32_, err := util.ParseVarInt(data, &pos)
+						if err != nil {
+							return 0, err
 						}
+						_ = v32_
+
 						// skipping
 					case typeMap.T_LONG:
-						v64_ = 0
-						for shift = uint(0); shift <= 56; shift += 7 {
-							if pos >= l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							b_ = data[pos]
-							pos++
-							if shift == 56 {
-								v64_ |= uint64(b_&0xFF) << shift
-								break
-							} else {
-								v64_ |= uint64(b_&0x7F) << shift
-								if b_ < 0x80 {
-									break
-								}
-							}
+
+						v64_, err := util.ParseVarLong(data, &pos)
+						if err != nil {
+							return 0, err
 						}
+						_ = v64_
+
 						if bind.Fields[bindFieldIndex].uint64 != nil {
 							*bind.Fields[bindFieldIndex].uint64 = v64_
 						}
 					case typeMap.T_BOOLEAN:
-						if pos >= l {
-							return 0, io.ErrUnexpectedEOF
+
+						b_, err := util.ParseByte(data, &pos)
+						if err != nil {
+							return 0, err
 						}
-						b_ = data[pos]
-						pos++
+						_ = b_
+
 						// skipping
 					case typeMap.T_FLOAT:
-						v32_ = uint32(0)
-						for shift = uint(0); ; shift += 7 {
-							if shift >= 32 {
-								return 0, def.ErrIntOverflow
-							}
-							if pos >= l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							b_ = data[pos]
-							pos++
-							v32_ |= uint32(b_&0x7F) << shift
-							if b_ < 0x80 {
-								break
-							}
+
+						v32_, err := util.ParseVarInt(data, &pos)
+						if err != nil {
+							return 0, err
 						}
+						_ = v32_
+
 						// skipping
 					default:
 						bindFieldType := typeMap.IDMap[bind.Fields[bindFieldIndex].Field.Type]
@@ -265,135 +169,66 @@ func (this *ThreadList) Parse(data []byte, bind *BindThread, typeMap *def.TypeMa
 						}
 						bindSkipObjects := 1
 						if bind.Fields[bindFieldIndex].Field.Array {
-							v32_ = uint32(0)
-							for shift = uint(0); ; shift += 7 {
-								if shift >= 32 {
-									return 0, def.ErrIntOverflow
-								}
-								if pos >= l {
-									return 0, io.ErrUnexpectedEOF
-								}
-								b_ = data[pos]
-								pos++
-								v32_ |= uint32(b_&0x7F) << shift
-								if b_ < 0x80 {
-									break
-								}
+
+							v32_, err := util.ParseVarInt(data, &pos)
+							if err != nil {
+								return 0, err
 							}
+							_ = v32_
+
 							bindSkipObjects = int(v32_)
 						}
 						for bindSkipObjectIndex := 0; bindSkipObjectIndex < bindSkipObjects; bindSkipObjectIndex++ {
 							for bindskipFieldIndex := 0; bindskipFieldIndex < len(bindFieldType.Fields); bindskipFieldIndex++ {
 								bindSkipFieldType := bindFieldType.Fields[bindskipFieldIndex].Type
 								if bindFieldType.Fields[bindskipFieldIndex].ConstantPool {
-									v32_ = uint32(0)
-									for shift = uint(0); ; shift += 7 {
-										if shift >= 32 {
-											return 0, def.ErrIntOverflow
-										}
-										if pos >= l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										b_ = data[pos]
-										pos++
-										v32_ |= uint32(b_&0x7F) << shift
-										if b_ < 0x80 {
-											break
-										}
+
+									v32_, err := util.ParseVarInt(data, &pos)
+									if err != nil {
+										return 0, err
 									}
+									_ = v32_
+
 								} else if bindSkipFieldType == typeMap.T_STRING {
-									s_ = ""
-									if pos >= l {
-										return 0, io.ErrUnexpectedEOF
+
+									s_, err := util.ParseString(data, &pos)
+									if err != nil {
+										return 0, err
 									}
-									b_ = data[pos]
-									pos++
-									switch b_ {
-									case 0:
-										break
-									case 1:
-										break
-									case 3:
-										v32_ = uint32(0)
-										for shift = uint(0); ; shift += 7 {
-											if shift >= 32 {
-												return 0, def.ErrIntOverflow
-											}
-											if pos >= l {
-												return 0, io.ErrUnexpectedEOF
-											}
-											b_ = data[pos]
-											pos++
-											v32_ |= uint32(b_&0x7F) << shift
-											if b_ < 0x80 {
-												break
-											}
-										}
-										if pos+int(v32_) > l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										bs := data[pos : pos+int(v32_)]
-										s_ = *(*string)(unsafe.Pointer(&bs))
-										pos += int(v32_)
-									default:
-										return 0, fmt.Errorf("unknown string type %d at %d", b_, pos)
-									}
+									_ = s_
+
 								} else if bindSkipFieldType == typeMap.T_INT {
-									v32_ = uint32(0)
-									for shift = uint(0); ; shift += 7 {
-										if shift >= 32 {
-											return 0, def.ErrIntOverflow
-										}
-										if pos >= l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										b_ = data[pos]
-										pos++
-										v32_ |= uint32(b_&0x7F) << shift
-										if b_ < 0x80 {
-											break
-										}
+
+									v32_, err := util.ParseVarInt(data, &pos)
+									if err != nil {
+										return 0, err
 									}
+									_ = v32_
+
 								} else if bindSkipFieldType == typeMap.T_FLOAT {
-									v32_ = uint32(0)
-									for shift = uint(0); ; shift += 7 {
-										if shift >= 32 {
-											return 0, def.ErrIntOverflow
-										}
-										if pos >= l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										b_ = data[pos]
-										pos++
-										v32_ |= uint32(b_&0x7F) << shift
-										if b_ < 0x80 {
-											break
-										}
+
+									v32_, err := util.ParseVarInt(data, &pos)
+									if err != nil {
+										return 0, err
 									}
+									_ = v32_
+
 								} else if bindSkipFieldType == typeMap.T_LONG {
-									v64_ = 0
-									for shift = uint(0); shift <= 56; shift += 7 {
-										if pos >= l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										b_ = data[pos]
-										pos++
-										if shift == 56 {
-											v64_ |= uint64(b_&0xFF) << shift
-											break
-										} else {
-											v64_ |= uint64(b_&0x7F) << shift
-											if b_ < 0x80 {
-												break
-											}
-										}
+
+									v64_, err := util.ParseVarLong(data, &pos)
+									if err != nil {
+										return 0, err
 									}
+									_ = v64_
+
 								} else if bindSkipFieldType == typeMap.T_BOOLEAN {
-									if pos >= l {
-										return 0, io.ErrUnexpectedEOF
+
+									b_, err := util.ParseByte(data, &pos)
+									if err != nil {
+										return 0, err
 									}
-									b_ = data[pos]
-									pos++
+									_ = b_
+
 								} else {
 									return 0, fmt.Errorf("nested objects not implemented. ")
 								}

--- a/parser/types/thread_park.go
+++ b/parser/types/thread_park.go
@@ -4,9 +4,9 @@ package types
 
 import (
 	"fmt"
+
 	"github.com/grafana/jfr-parser/parser/types/def"
-	"io"
-	"unsafe"
+	"github.com/grafana/jfr-parser/util"
 )
 
 type BindThreadPark struct {
@@ -101,54 +101,27 @@ type ThreadPark struct {
 }
 
 func (this *ThreadPark) Parse(data []byte, bind *BindThreadPark, typeMap *def.TypeMap) (pos int, err error) {
-	var (
-		v64_  uint64
-		v32_  uint32
-		s_    string
-		b_    byte
-		shift = uint(0)
-		l     = len(data)
-	)
-	_ = v64_
-	_ = v32_
-	_ = s_
 	for bindFieldIndex := 0; bindFieldIndex < len(bind.Fields); bindFieldIndex++ {
 		bindArraySize := 1
 		if bind.Fields[bindFieldIndex].Field.Array {
-			v32_ = uint32(0)
-			for shift = uint(0); ; shift += 7 {
-				if shift >= 32 {
-					return 0, def.ErrIntOverflow
-				}
-				if pos >= l {
-					return 0, io.ErrUnexpectedEOF
-				}
-				b_ = data[pos]
-				pos++
-				v32_ |= uint32(b_&0x7F) << shift
-				if b_ < 0x80 {
-					break
-				}
+
+			v32_, err := util.ParseVarInt(data, &pos)
+			if err != nil {
+				return 0, err
 			}
+			_ = v32_
+
 			bindArraySize = int(v32_)
 		}
 		for bindArrayIndex := 0; bindArrayIndex < bindArraySize; bindArrayIndex++ {
 			if bind.Fields[bindFieldIndex].Field.ConstantPool {
-				v32_ = uint32(0)
-				for shift = uint(0); ; shift += 7 {
-					if shift >= 32 {
-						return 0, def.ErrIntOverflow
-					}
-					if pos >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b_ = data[pos]
-					pos++
-					v32_ |= uint32(b_&0x7F) << shift
-					if b_ < 0x80 {
-						break
-					}
+
+				v32_, err := util.ParseVarInt(data, &pos)
+				if err != nil {
+					return 0, err
 				}
+				_ = v32_
+
 				switch bind.Fields[bindFieldIndex].Field.Type {
 				case typeMap.T_THREAD:
 					if bind.Fields[bindFieldIndex].ThreadRef != nil {
@@ -167,104 +140,51 @@ func (this *ThreadPark) Parse(data []byte, bind *BindThreadPark, typeMap *def.Ty
 				bindFieldTypeID := bind.Fields[bindFieldIndex].Field.Type
 				switch bindFieldTypeID {
 				case typeMap.T_STRING:
-					s_ = ""
-					if pos >= l {
-						return 0, io.ErrUnexpectedEOF
+
+					s_, err := util.ParseString(data, &pos)
+					if err != nil {
+						return 0, err
 					}
-					b_ = data[pos]
-					pos++
-					switch b_ {
-					case 0:
-						break
-					case 1:
-						break
-					case 3:
-						v32_ = uint32(0)
-						for shift = uint(0); ; shift += 7 {
-							if shift >= 32 {
-								return 0, def.ErrIntOverflow
-							}
-							if pos >= l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							b_ = data[pos]
-							pos++
-							v32_ |= uint32(b_&0x7F) << shift
-							if b_ < 0x80 {
-								break
-							}
-						}
-						if pos+int(v32_) > l {
-							return 0, io.ErrUnexpectedEOF
-						}
-						bs := data[pos : pos+int(v32_)]
-						s_ = *(*string)(unsafe.Pointer(&bs))
-						pos += int(v32_)
-					default:
-						return 0, fmt.Errorf("unknown string type %d at %d", b_, pos)
-					}
+					_ = s_
+
 					// skipping
 				case typeMap.T_INT:
-					v32_ = uint32(0)
-					for shift = uint(0); ; shift += 7 {
-						if shift >= 32 {
-							return 0, def.ErrIntOverflow
-						}
-						if pos >= l {
-							return 0, io.ErrUnexpectedEOF
-						}
-						b_ = data[pos]
-						pos++
-						v32_ |= uint32(b_&0x7F) << shift
-						if b_ < 0x80 {
-							break
-						}
+
+					v32_, err := util.ParseVarInt(data, &pos)
+					if err != nil {
+						return 0, err
 					}
+					_ = v32_
+
 					// skipping
 				case typeMap.T_LONG:
-					v64_ = 0
-					for shift = uint(0); shift <= 56; shift += 7 {
-						if pos >= l {
-							return 0, io.ErrUnexpectedEOF
-						}
-						b_ = data[pos]
-						pos++
-						if shift == 56 {
-							v64_ |= uint64(b_&0xFF) << shift
-							break
-						} else {
-							v64_ |= uint64(b_&0x7F) << shift
-							if b_ < 0x80 {
-								break
-							}
-						}
+
+					v64_, err := util.ParseVarLong(data, &pos)
+					if err != nil {
+						return 0, err
 					}
+					_ = v64_
+
 					if bind.Fields[bindFieldIndex].uint64 != nil {
 						*bind.Fields[bindFieldIndex].uint64 = v64_
 					}
 				case typeMap.T_BOOLEAN:
-					if pos >= l {
-						return 0, io.ErrUnexpectedEOF
+
+					b_, err := util.ParseByte(data, &pos)
+					if err != nil {
+						return 0, err
 					}
-					b_ = data[pos]
-					pos++
+					_ = b_
+
 					// skipping
 				case typeMap.T_FLOAT:
-					v32_ = uint32(0)
-					for shift = uint(0); ; shift += 7 {
-						if shift >= 32 {
-							return 0, def.ErrIntOverflow
-						}
-						if pos >= l {
-							return 0, io.ErrUnexpectedEOF
-						}
-						b_ = data[pos]
-						pos++
-						v32_ |= uint32(b_&0x7F) << shift
-						if b_ < 0x80 {
-							break
-						}
+
+					v32_, err := util.ParseVarInt(data, &pos)
+					if err != nil {
+						return 0, err
 					}
+					_ = v32_
+
 					// skipping
 				default:
 					bindFieldType := typeMap.IDMap[bind.Fields[bindFieldIndex].Field.Type]
@@ -273,135 +193,66 @@ func (this *ThreadPark) Parse(data []byte, bind *BindThreadPark, typeMap *def.Ty
 					}
 					bindSkipObjects := 1
 					if bind.Fields[bindFieldIndex].Field.Array {
-						v32_ = uint32(0)
-						for shift = uint(0); ; shift += 7 {
-							if shift >= 32 {
-								return 0, def.ErrIntOverflow
-							}
-							if pos >= l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							b_ = data[pos]
-							pos++
-							v32_ |= uint32(b_&0x7F) << shift
-							if b_ < 0x80 {
-								break
-							}
+
+						v32_, err := util.ParseVarInt(data, &pos)
+						if err != nil {
+							return 0, err
 						}
+						_ = v32_
+
 						bindSkipObjects = int(v32_)
 					}
 					for bindSkipObjectIndex := 0; bindSkipObjectIndex < bindSkipObjects; bindSkipObjectIndex++ {
 						for bindskipFieldIndex := 0; bindskipFieldIndex < len(bindFieldType.Fields); bindskipFieldIndex++ {
 							bindSkipFieldType := bindFieldType.Fields[bindskipFieldIndex].Type
 							if bindFieldType.Fields[bindskipFieldIndex].ConstantPool {
-								v32_ = uint32(0)
-								for shift = uint(0); ; shift += 7 {
-									if shift >= 32 {
-										return 0, def.ErrIntOverflow
-									}
-									if pos >= l {
-										return 0, io.ErrUnexpectedEOF
-									}
-									b_ = data[pos]
-									pos++
-									v32_ |= uint32(b_&0x7F) << shift
-									if b_ < 0x80 {
-										break
-									}
+
+								v32_, err := util.ParseVarInt(data, &pos)
+								if err != nil {
+									return 0, err
 								}
+								_ = v32_
+
 							} else if bindSkipFieldType == typeMap.T_STRING {
-								s_ = ""
-								if pos >= l {
-									return 0, io.ErrUnexpectedEOF
+
+								s_, err := util.ParseString(data, &pos)
+								if err != nil {
+									return 0, err
 								}
-								b_ = data[pos]
-								pos++
-								switch b_ {
-								case 0:
-									break
-								case 1:
-									break
-								case 3:
-									v32_ = uint32(0)
-									for shift = uint(0); ; shift += 7 {
-										if shift >= 32 {
-											return 0, def.ErrIntOverflow
-										}
-										if pos >= l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										b_ = data[pos]
-										pos++
-										v32_ |= uint32(b_&0x7F) << shift
-										if b_ < 0x80 {
-											break
-										}
-									}
-									if pos+int(v32_) > l {
-										return 0, io.ErrUnexpectedEOF
-									}
-									bs := data[pos : pos+int(v32_)]
-									s_ = *(*string)(unsafe.Pointer(&bs))
-									pos += int(v32_)
-								default:
-									return 0, fmt.Errorf("unknown string type %d at %d", b_, pos)
-								}
+								_ = s_
+
 							} else if bindSkipFieldType == typeMap.T_INT {
-								v32_ = uint32(0)
-								for shift = uint(0); ; shift += 7 {
-									if shift >= 32 {
-										return 0, def.ErrIntOverflow
-									}
-									if pos >= l {
-										return 0, io.ErrUnexpectedEOF
-									}
-									b_ = data[pos]
-									pos++
-									v32_ |= uint32(b_&0x7F) << shift
-									if b_ < 0x80 {
-										break
-									}
+
+								v32_, err := util.ParseVarInt(data, &pos)
+								if err != nil {
+									return 0, err
 								}
+								_ = v32_
+
 							} else if bindSkipFieldType == typeMap.T_FLOAT {
-								v32_ = uint32(0)
-								for shift = uint(0); ; shift += 7 {
-									if shift >= 32 {
-										return 0, def.ErrIntOverflow
-									}
-									if pos >= l {
-										return 0, io.ErrUnexpectedEOF
-									}
-									b_ = data[pos]
-									pos++
-									v32_ |= uint32(b_&0x7F) << shift
-									if b_ < 0x80 {
-										break
-									}
+
+								v32_, err := util.ParseVarInt(data, &pos)
+								if err != nil {
+									return 0, err
 								}
+								_ = v32_
+
 							} else if bindSkipFieldType == typeMap.T_LONG {
-								v64_ = 0
-								for shift = uint(0); shift <= 56; shift += 7 {
-									if pos >= l {
-										return 0, io.ErrUnexpectedEOF
-									}
-									b_ = data[pos]
-									pos++
-									if shift == 56 {
-										v64_ |= uint64(b_&0xFF) << shift
-										break
-									} else {
-										v64_ |= uint64(b_&0x7F) << shift
-										if b_ < 0x80 {
-											break
-										}
-									}
+
+								v64_, err := util.ParseVarLong(data, &pos)
+								if err != nil {
+									return 0, err
 								}
+								_ = v64_
+
 							} else if bindSkipFieldType == typeMap.T_BOOLEAN {
-								if pos >= l {
-									return 0, io.ErrUnexpectedEOF
+
+								b_, err := util.ParseByte(data, &pos)
+								if err != nil {
+									return 0, err
 								}
-								b_ = data[pos]
-								pos++
+								_ = b_
+
 							} else {
 								return 0, fmt.Errorf("nested objects not implemented. ")
 							}

--- a/parser/types/threadstate.go
+++ b/parser/types/threadstate.go
@@ -4,9 +4,9 @@ package types
 
 import (
 	"fmt"
+
 	"github.com/grafana/jfr-parser/parser/types/def"
-	"io"
-	"unsafe"
+	"github.com/grafana/jfr-parser/util"
 )
 
 type BindThreadState struct {
@@ -48,191 +48,95 @@ type ThreadState struct {
 }
 
 func (this *ThreadStateList) Parse(data []byte, bind *BindThreadState, typeMap *def.TypeMap) (pos int, err error) {
-	var (
-		v64_  uint64
-		v32_  uint32
-		s_    string
-		b_    byte
-		shift = uint(0)
-		l     = len(data)
-	)
-	_ = v64_
-	_ = v32_
-	_ = s_
-	v32_ = uint32(0)
-	for shift = uint(0); ; shift += 7 {
-		if shift >= 32 {
-			return 0, def.ErrIntOverflow
-		}
-		if pos >= l {
-			return 0, io.ErrUnexpectedEOF
-		}
-		b_ = data[pos]
-		pos++
-		v32_ |= uint32(b_&0x7F) << shift
-		if b_ < 0x80 {
-			break
-		}
+
+	v32_, err := util.ParseVarInt(data, &pos)
+	if err != nil {
+		return 0, err
 	}
+	_ = v32_
+
 	n := int(v32_)
 	this.IDMap = make(map[ThreadStateRef]uint32, n)
 	this.ThreadState = make([]ThreadState, n)
 	for i := 0; i < n; i++ {
-		v32_ = uint32(0)
-		for shift = uint(0); ; shift += 7 {
-			if shift >= 32 {
-				return 0, def.ErrIntOverflow
-			}
-			if pos >= l {
-				return 0, io.ErrUnexpectedEOF
-			}
-			b_ = data[pos]
-			pos++
-			v32_ |= uint32(b_&0x7F) << shift
-			if b_ < 0x80 {
-				break
-			}
+
+		v32_, err := util.ParseVarInt(data, &pos)
+		if err != nil {
+			return 0, err
 		}
+		_ = v32_
+
 		id := ThreadStateRef(v32_)
 		for bindFieldIndex := 0; bindFieldIndex < len(bind.Fields); bindFieldIndex++ {
 			bindArraySize := 1
 			if bind.Fields[bindFieldIndex].Field.Array {
-				v32_ = uint32(0)
-				for shift = uint(0); ; shift += 7 {
-					if shift >= 32 {
-						return 0, def.ErrIntOverflow
-					}
-					if pos >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b_ = data[pos]
-					pos++
-					v32_ |= uint32(b_&0x7F) << shift
-					if b_ < 0x80 {
-						break
-					}
+
+				v32_, err := util.ParseVarInt(data, &pos)
+				if err != nil {
+					return 0, err
 				}
+				_ = v32_
+
 				bindArraySize = int(v32_)
 			}
 			for bindArrayIndex := 0; bindArrayIndex < bindArraySize; bindArrayIndex++ {
 				if bind.Fields[bindFieldIndex].Field.ConstantPool {
-					v32_ = uint32(0)
-					for shift = uint(0); ; shift += 7 {
-						if shift >= 32 {
-							return 0, def.ErrIntOverflow
-						}
-						if pos >= l {
-							return 0, io.ErrUnexpectedEOF
-						}
-						b_ = data[pos]
-						pos++
-						v32_ |= uint32(b_&0x7F) << shift
-						if b_ < 0x80 {
-							break
-						}
+
+					v32_, err := util.ParseVarInt(data, &pos)
+					if err != nil {
+						return 0, err
 					}
+					_ = v32_
+
 				} else {
 					bindFieldTypeID := bind.Fields[bindFieldIndex].Field.Type
 					switch bindFieldTypeID {
 					case typeMap.T_STRING:
-						s_ = ""
-						if pos >= l {
-							return 0, io.ErrUnexpectedEOF
+
+						s_, err := util.ParseString(data, &pos)
+						if err != nil {
+							return 0, err
 						}
-						b_ = data[pos]
-						pos++
-						switch b_ {
-						case 0:
-							break
-						case 1:
-							break
-						case 3:
-							v32_ = uint32(0)
-							for shift = uint(0); ; shift += 7 {
-								if shift >= 32 {
-									return 0, def.ErrIntOverflow
-								}
-								if pos >= l {
-									return 0, io.ErrUnexpectedEOF
-								}
-								b_ = data[pos]
-								pos++
-								v32_ |= uint32(b_&0x7F) << shift
-								if b_ < 0x80 {
-									break
-								}
-							}
-							if pos+int(v32_) > l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							bs := data[pos : pos+int(v32_)]
-							s_ = *(*string)(unsafe.Pointer(&bs))
-							pos += int(v32_)
-						default:
-							return 0, fmt.Errorf("unknown string type %d at %d", b_, pos)
-						}
+						_ = s_
+
 						if bind.Fields[bindFieldIndex].string != nil {
 							*bind.Fields[bindFieldIndex].string = s_
 						}
 					case typeMap.T_INT:
-						v32_ = uint32(0)
-						for shift = uint(0); ; shift += 7 {
-							if shift >= 32 {
-								return 0, def.ErrIntOverflow
-							}
-							if pos >= l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							b_ = data[pos]
-							pos++
-							v32_ |= uint32(b_&0x7F) << shift
-							if b_ < 0x80 {
-								break
-							}
+
+						v32_, err := util.ParseVarInt(data, &pos)
+						if err != nil {
+							return 0, err
 						}
+						_ = v32_
+
 						// skipping
 					case typeMap.T_LONG:
-						v64_ = 0
-						for shift = uint(0); shift <= 56; shift += 7 {
-							if pos >= l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							b_ = data[pos]
-							pos++
-							if shift == 56 {
-								v64_ |= uint64(b_&0xFF) << shift
-								break
-							} else {
-								v64_ |= uint64(b_&0x7F) << shift
-								if b_ < 0x80 {
-									break
-								}
-							}
+
+						v64_, err := util.ParseVarLong(data, &pos)
+						if err != nil {
+							return 0, err
 						}
+						_ = v64_
+
 						// skipping
 					case typeMap.T_BOOLEAN:
-						if pos >= l {
-							return 0, io.ErrUnexpectedEOF
+
+						b_, err := util.ParseByte(data, &pos)
+						if err != nil {
+							return 0, err
 						}
-						b_ = data[pos]
-						pos++
+						_ = b_
+
 						// skipping
 					case typeMap.T_FLOAT:
-						v32_ = uint32(0)
-						for shift = uint(0); ; shift += 7 {
-							if shift >= 32 {
-								return 0, def.ErrIntOverflow
-							}
-							if pos >= l {
-								return 0, io.ErrUnexpectedEOF
-							}
-							b_ = data[pos]
-							pos++
-							v32_ |= uint32(b_&0x7F) << shift
-							if b_ < 0x80 {
-								break
-							}
+
+						v32_, err := util.ParseVarInt(data, &pos)
+						if err != nil {
+							return 0, err
 						}
+						_ = v32_
+
 						// skipping
 					default:
 						bindFieldType := typeMap.IDMap[bind.Fields[bindFieldIndex].Field.Type]
@@ -241,135 +145,66 @@ func (this *ThreadStateList) Parse(data []byte, bind *BindThreadState, typeMap *
 						}
 						bindSkipObjects := 1
 						if bind.Fields[bindFieldIndex].Field.Array {
-							v32_ = uint32(0)
-							for shift = uint(0); ; shift += 7 {
-								if shift >= 32 {
-									return 0, def.ErrIntOverflow
-								}
-								if pos >= l {
-									return 0, io.ErrUnexpectedEOF
-								}
-								b_ = data[pos]
-								pos++
-								v32_ |= uint32(b_&0x7F) << shift
-								if b_ < 0x80 {
-									break
-								}
+
+							v32_, err := util.ParseVarInt(data, &pos)
+							if err != nil {
+								return 0, err
 							}
+							_ = v32_
+
 							bindSkipObjects = int(v32_)
 						}
 						for bindSkipObjectIndex := 0; bindSkipObjectIndex < bindSkipObjects; bindSkipObjectIndex++ {
 							for bindskipFieldIndex := 0; bindskipFieldIndex < len(bindFieldType.Fields); bindskipFieldIndex++ {
 								bindSkipFieldType := bindFieldType.Fields[bindskipFieldIndex].Type
 								if bindFieldType.Fields[bindskipFieldIndex].ConstantPool {
-									v32_ = uint32(0)
-									for shift = uint(0); ; shift += 7 {
-										if shift >= 32 {
-											return 0, def.ErrIntOverflow
-										}
-										if pos >= l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										b_ = data[pos]
-										pos++
-										v32_ |= uint32(b_&0x7F) << shift
-										if b_ < 0x80 {
-											break
-										}
+
+									v32_, err := util.ParseVarInt(data, &pos)
+									if err != nil {
+										return 0, err
 									}
+									_ = v32_
+
 								} else if bindSkipFieldType == typeMap.T_STRING {
-									s_ = ""
-									if pos >= l {
-										return 0, io.ErrUnexpectedEOF
+
+									s_, err := util.ParseString(data, &pos)
+									if err != nil {
+										return 0, err
 									}
-									b_ = data[pos]
-									pos++
-									switch b_ {
-									case 0:
-										break
-									case 1:
-										break
-									case 3:
-										v32_ = uint32(0)
-										for shift = uint(0); ; shift += 7 {
-											if shift >= 32 {
-												return 0, def.ErrIntOverflow
-											}
-											if pos >= l {
-												return 0, io.ErrUnexpectedEOF
-											}
-											b_ = data[pos]
-											pos++
-											v32_ |= uint32(b_&0x7F) << shift
-											if b_ < 0x80 {
-												break
-											}
-										}
-										if pos+int(v32_) > l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										bs := data[pos : pos+int(v32_)]
-										s_ = *(*string)(unsafe.Pointer(&bs))
-										pos += int(v32_)
-									default:
-										return 0, fmt.Errorf("unknown string type %d at %d", b_, pos)
-									}
+									_ = s_
+
 								} else if bindSkipFieldType == typeMap.T_INT {
-									v32_ = uint32(0)
-									for shift = uint(0); ; shift += 7 {
-										if shift >= 32 {
-											return 0, def.ErrIntOverflow
-										}
-										if pos >= l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										b_ = data[pos]
-										pos++
-										v32_ |= uint32(b_&0x7F) << shift
-										if b_ < 0x80 {
-											break
-										}
+
+									v32_, err := util.ParseVarInt(data, &pos)
+									if err != nil {
+										return 0, err
 									}
+									_ = v32_
+
 								} else if bindSkipFieldType == typeMap.T_FLOAT {
-									v32_ = uint32(0)
-									for shift = uint(0); ; shift += 7 {
-										if shift >= 32 {
-											return 0, def.ErrIntOverflow
-										}
-										if pos >= l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										b_ = data[pos]
-										pos++
-										v32_ |= uint32(b_&0x7F) << shift
-										if b_ < 0x80 {
-											break
-										}
+
+									v32_, err := util.ParseVarInt(data, &pos)
+									if err != nil {
+										return 0, err
 									}
+									_ = v32_
+
 								} else if bindSkipFieldType == typeMap.T_LONG {
-									v64_ = 0
-									for shift = uint(0); shift <= 56; shift += 7 {
-										if pos >= l {
-											return 0, io.ErrUnexpectedEOF
-										}
-										b_ = data[pos]
-										pos++
-										if shift == 56 {
-											v64_ |= uint64(b_&0xFF) << shift
-											break
-										} else {
-											v64_ |= uint64(b_&0x7F) << shift
-											if b_ < 0x80 {
-												break
-											}
-										}
+
+									v64_, err := util.ParseVarLong(data, &pos)
+									if err != nil {
+										return 0, err
 									}
+									_ = v64_
+
 								} else if bindSkipFieldType == typeMap.T_BOOLEAN {
-									if pos >= l {
-										return 0, io.ErrUnexpectedEOF
+
+									b_, err := util.ParseByte(data, &pos)
+									if err != nil {
+										return 0, err
 									}
-									b_ = data[pos]
-									pos++
+									_ = b_
+
 								} else {
 									return 0, fmt.Errorf("nested objects not implemented. ")
 								}

--- a/util/parser.go
+++ b/util/parser.go
@@ -1,0 +1,117 @@
+package util
+
+import (
+	"fmt"
+	"io"
+	"unsafe"
+
+	"github.com/grafana/jfr-parser/parser/types/def"
+)
+
+func ParseVarInt(buf []byte, pos *int) (uint32, error) {
+	v := uint32(0)
+	for shift := uint(0); ; shift += 7 {
+		if shift >= 32 {
+			return 0, def.ErrIntOverflow
+		}
+		if *pos >= len(buf) {
+			return 0, io.ErrUnexpectedEOF
+		}
+		b := buf[*pos]
+		*pos++
+		v |= uint32(b&0x7F) << shift
+		if b < 0x80 {
+			break
+		}
+	}
+	return v, nil
+}
+
+func ParseVarLong(buf []byte, pos *int) (uint64, error) {
+	v := uint64(0)
+	for shift := uint(0); shift <= 56; shift += 7 {
+		if *pos >= len(buf) {
+			return 0, io.ErrUnexpectedEOF
+		}
+		b_ := buf[*pos]
+		*pos++
+		if shift == 56 {
+			v |= uint64(b_&0xFF) << shift
+			break
+		} else {
+			v |= uint64(b_&0x7F) << shift
+			if b_ < 0x80 {
+				break
+			}
+		}
+	}
+	return v, nil
+}
+
+func ParseString(buf []byte, pos *int) (string, error) {
+	if *pos >= len(buf) {
+		return "", io.ErrUnexpectedEOF
+	}
+
+	b := buf[*pos]
+	*pos++
+
+	switch b { //todo implement 2
+	case 0:
+		return "", nil //todo this should be nil
+	case 1:
+		return "", nil
+	case 3:
+		bs, err := ParseBytes(buf, pos)
+		if err != nil {
+			return "", err
+		}
+		str := *(*string)(unsafe.Pointer(&bs))
+		return str, nil
+	case 4:
+		return ParseCharArrayString(buf, pos)
+	default:
+		return "", fmt.Errorf("unknown string type %d", b)
+	}
+}
+
+func ParseByte(buf []byte, pos *int) (byte, error) {
+	if *pos >= len(buf) {
+		return 0, io.ErrUnexpectedEOF
+	}
+	b := buf[*pos]
+	*pos++
+	return b, nil
+
+}
+
+func ParseBytes(buf []byte, pos *int) ([]byte, error) {
+	l, err := ParseVarInt(buf, pos)
+	if err != nil {
+		return nil, err
+	}
+	if *pos+int(l) > len(buf) {
+		return nil, io.ErrUnexpectedEOF
+	}
+	bs := buf[*pos : *pos+int(l)]
+	*pos += int(l)
+	return bs, nil
+}
+
+func ParseCharArrayString(buf []byte, pos *int) (string, error) {
+	l, err := ParseVarInt(buf, pos)
+	if err != nil {
+		return "", err
+	}
+	chars := make([]rune, int(l))
+	for i := 0; i < int(l); i++ {
+		c, err := ParseVarInt(buf, pos)
+		if err != nil {
+			return "", err
+		}
+		chars[i] = rune(c)
+	}
+
+	res := string(chars)
+	return res, nil
+}


### PR DESCRIPTION
Branched from https://github.com/grafana/jfr-parser/pull/31

Extracts int, string and byte parsing implementation into parsing utilities to avoid redundant code.

The types are regenerated with parsing utilities.